### PR TITLE
Add SoundWire codec support, --speaker-info diagnostics, and psychoacoustic bass enhancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Converts Dolby Atmos DAX3 tuning XML extracted from Windows drivers into EasyEff
 | ThinkPad X1 Yoga Gen 7 | Realtek ALC287, 17AA:22E6 | author (primary development target) |
 | Lenovo Yoga 7 2-in-1 16AKP10 | — | [#1](https://github.com/antoinecellerier/speaker-tuning-to-easyeffects/issues/1) |
 | ThinkPad T14s Gen 6 AMD | — | [#3](https://github.com/antoinecellerier/speaker-tuning-to-easyeffects/issues/3) |
+| ThinkPad X1 Carbon Gen 13 | Soundwire 17AA:2339 | [PR7](https://github.com/antoinecellerier/speaker-tuning-to-easyeffects/pull/7/) |
 
 If you test it on other hardware, please open an issue with your device model and audio codec subsystem ID (`cat /proc/asound/card*/codec* | grep Subsystem`).
 
@@ -247,6 +248,27 @@ The tighter limiting at low frequencies protects laptop speakers from sub-bass d
 - IR files: `~/.local/share/easyeffects/irs/` with `.irs` extension (not `.wav`)
 - Convolver uses `"kernel-name"` (filename stem), not the deprecated `"kernel-path"`
 - Equalizer has no graphic EQ mode — only parametric (LSP plugin)
+
+### Flatpak EasyEffects
+
+The default `--output-dir` / `--irs-dir` point at the native-package XDG paths. The Flatpak build (`com.github.wwmm.easyeffects`) runs in a sandbox that does not have access to `~/.local/share/easyeffects/` by default, so presets written there are invisible to it. Two options:
+
+1. **Write directly into the Flatpak data directory**:
+   ```bash
+   python3 dolby_to_easyeffects.py ... \
+       --output-dir ~/.var/app/com.github.wwmm.easyeffects/data/easyeffects/output \
+       --irs-dir    ~/.var/app/com.github.wwmm.easyeffects/data/easyeffects/irs \
+       --autoload-dir ~/.var/app/com.github.wwmm.easyeffects/data/easyeffects/autoload/output
+   ```
+2. **Or grant the Flatpak read access to the native path**:
+   ```bash
+   flatpak override --user --filesystem=~/.local/share/easyeffects com.github.wwmm.easyeffects
+   ```
+   Then the script's defaults work. Verify with `flatpak run --command=easyeffects com.github.wwmm.easyeffects -p`.
+
+### SoundWire codecs (newer Intel platforms)
+
+Auto-detection also handles SoundWire-based audio (Lunar Lake and later, Meteor Lake, some Tiger/Alder Lake SKUs). The script reads device IDs from `/sys/bus/soundwire/devices/` and the PCI subsystem ID of the HD Audio controller from `/sys/class/sound/card*/device`, and matches them against Dolby filenames of the form `SOUNDWIRE_MAN_<man>_FUNC_<func>_SUBSYS_<device><vendor>.xml` (e.g. `SOUNDWIRE_MAN_025D_FUNC_1318_SUBSYS_233917AA.xml`). `--windows` accepts either a full Windows system root *or* an already-extracted DriverStore directory containing `dax3_ext_*.inf_*` subfolders directly.
 
 ## What's not implemented
 

--- a/README.md
+++ b/README.md
@@ -251,20 +251,7 @@ The tighter limiting at low frequencies protects laptop speakers from sub-bass d
 
 ### Flatpak EasyEffects
 
-The default `--output-dir` / `--irs-dir` point at the native-package XDG paths. The Flatpak build (`com.github.wwmm.easyeffects`) runs in a sandbox that does not have access to `~/.local/share/easyeffects/` by default, so presets written there are invisible to it. Two options:
-
-1. **Write directly into the Flatpak data directory**:
-   ```bash
-   python3 dolby_to_easyeffects.py ... \
-       --output-dir ~/.var/app/com.github.wwmm.easyeffects/data/easyeffects/output \
-       --irs-dir    ~/.var/app/com.github.wwmm.easyeffects/data/easyeffects/irs \
-       --autoload-dir ~/.var/app/com.github.wwmm.easyeffects/data/easyeffects/autoload/output
-   ```
-2. **Or grant the Flatpak read access to the native path**:
-   ```bash
-   flatpak override --user --filesystem=~/.local/share/easyeffects com.github.wwmm.easyeffects
-   ```
-   Then the script's defaults work. Verify with `flatpak run --command=easyeffects com.github.wwmm.easyeffects -p`.
+The script auto-detects whether EasyEffects is installed via Flatpak or as a native package. If `~/.var/app/com.github.wwmm.easyeffects/config/easyeffects/` exists, it writes presets there; otherwise it falls back to the native `~/.local/share/easyeffects/` path. You can still override with `--output-dir`, `--irs-dir`, and `--autoload-dir`.
 
 ### SoundWire codecs (newer Intel platforms)
 

--- a/dolby_to_easyeffects.py
+++ b/dolby_to_easyeffects.py
@@ -126,6 +126,133 @@ def get_pci_audio_subsystem():
     return None
 
 
+def report_speaker_info():
+    """Report detected audio hardware and speaker layout."""
+    import platform
+
+    print("=== System ===")
+    dmi_product = Path("/sys/class/dmi/id/product_name")
+    dmi_family = Path("/sys/class/dmi/id/product_family")
+    if dmi_product.exists():
+        print(f"  Product: {dmi_product.read_text().strip()}")
+    if dmi_family.exists():
+        print(f"  Family:  {dmi_family.read_text().strip()}")
+    print(f"  Kernel:  {platform.release()}")
+
+    print("\n=== Sound cards ===")
+    cards_path = Path("/proc/asound/cards")
+    if cards_path.exists():
+        for line in cards_path.read_text().strip().splitlines():
+            print(f"  {line.strip()}")
+    else:
+        print("  (none found)")
+
+    print("\n=== HDA codecs ===")
+    hda = get_hda_codec_ids()
+    if hda:
+        for vendor_id, subsys_id in hda:
+            print(f"  Vendor: 0x{vendor_id}  Subsystem: 0x{subsys_id}")
+    else:
+        print("  (none)")
+
+    print("\n=== SoundWire devices ===")
+    sdw_path = Path("/sys/bus/soundwire/devices")
+    sdw = get_soundwire_ids()
+    if sdw:
+        for man_id, part_id in sdw:
+            print(f"  Manufacturer: 0x{man_id}  Part: 0x{part_id}")
+    else:
+        print("  (none)")
+
+    print("\n=== PCI audio subsystem ===")
+    pci = get_pci_audio_subsystem()
+    if pci:
+        print(f"  Subsystem: {pci[0]}:{pci[1]}")
+    else:
+        print("  (none)")
+
+    print("\n=== Speaker amplifiers ===")
+    amp_count = 0
+    amp_names = []
+    if sdw_path.is_dir():
+        for dev_dir in sorted(sdw_path.iterdir()):
+            match = re.match(
+                r"sdw:\d+:\d+:([0-9a-fA-F]{4}):([0-9a-fA-F]{4}):\d+",
+                dev_dir.name,
+            )
+            if not match:
+                continue
+            part_id = match.group(2).upper()
+            driver_link = dev_dir / "driver"
+            driver_name = ""
+            if driver_link.is_symlink():
+                driver_name = driver_link.resolve().name
+            # Speaker amplifier codecs (Realtek RT1316/RT1318/RT1320 etc.)
+            # are distinguishable from CODEC devices (RT711/RT712/RT713)
+            # by their part ID range or driver name.
+            is_amp = (
+                "rt13" in driver_name.lower()
+                or "rt_amp" in driver_name.lower()
+                or "max98" in driver_name.lower()
+                or "cs35" in driver_name.lower()
+            )
+            if is_amp:
+                amp_count += 1
+                amp_names.append(f"{dev_dir.name} (driver: {driver_name})")
+            else:
+                print(f"  Codec: {dev_dir.name} (driver: {driver_name})")
+
+    # Also check ALSA mixer for speaker amp controls
+    alsa_amps = set()
+    try:
+        result = subprocess.run(
+            ["amixer", "-c0", "scontrols"],
+            capture_output=True, text=True, timeout=5,
+        )
+        for line in result.stdout.splitlines():
+            # e.g. "Simple mixer control 'rt1318-1 DAC',0"
+            m = re.search(r"'(rt\d+[^']*|max98[^']*|cs35[^']*)\s+DAC'", line, re.I)
+            if m:
+                alsa_amps.add(m.group(1))
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    if amp_names:
+        for name in amp_names:
+            print(f"  Amplifier: {name}")
+    elif alsa_amps:
+        for name in sorted(alsa_amps):
+            print(f"  Amplifier: {name} (from ALSA mixer)")
+        amp_count = len(alsa_amps)
+
+    if amp_count == 0:
+        print("  (no speaker amplifiers detected)")
+
+    print("\n=== PCM playback devices ===")
+    for pcm_dir in sorted(Path("/proc/asound/card0").glob("pcm*p")):
+        info_path = pcm_dir / "info"
+        if not info_path.exists():
+            continue
+        info = {}
+        for line in info_path.read_text().splitlines():
+            if ": " in line:
+                k, v = line.split(": ", 1)
+                info[k.strip()] = v.strip()
+        stream_id = info.get("id", "?")
+        print(f"  pcm{info.get('device', '?')}p: {stream_id}")
+
+    print("\n=== Speaker layout estimate ===")
+    if amp_count >= 2:
+        print(f"  {amp_count} amplifiers detected → likely multi-way "
+              f"(woofer + tweeter) or multi-driver setup")
+    elif amp_count == 1:
+        print(f"  1 amplifier detected → likely full-range speakers (no dedicated tweeters)")
+    else:
+        print(f"  Could not determine speaker layout (no SoundWire amplifiers found)")
+        if hda:
+            print(f"  HDA codec detected — speaker layout not discoverable via sysfs")
+
+
 def find_tuning_xml(windows_root: Path):
     """Find the DAX3 tuning XML matching this machine's audio hardware.
 
@@ -1368,7 +1495,16 @@ def main():
         default=DEFAULT_AUTOLOAD_DIR,
         help=f"EasyEffects autoload directory (default: {DEFAULT_AUTOLOAD_DIR})",
     )
+    parser.add_argument(
+        "--speaker-info",
+        action="store_true",
+        help="report detected audio hardware and speaker layout, then exit",
+    )
     args = parser.parse_args()
+
+    if args.speaker_info:
+        report_speaker_info()
+        return
 
     # Resolve the XML file path
     if args.xml_file and args.windows:

--- a/dolby_to_easyeffects.py
+++ b/dolby_to_easyeffects.py
@@ -11,6 +11,7 @@ directly implements the exact target frequency response.
 
 Output chain:
   - convolver#0: IEQ curve + audio-optimizer (as FIR impulse response)
+  - bass_enhancer#0: psychoacoustic bass via harmonic generation
   - stereo_tools#0: surround virtualizer (stereo widening from surround-boost)
   - equalizer#0: speaker PEQ bells + high-pass (parametric filters from Dolby)
   - equalizer#1: dialog enhancer (speech presence boost from dialog-enhancer settings)
@@ -1445,6 +1446,31 @@ def make_regulator(regulator, freqs):
     return result
 
 
+def make_bass_enhancer(hp_freq: float, amount: float = 12.0) -> dict:
+    """Psychoacoustic bass enhancement via harmonic generation.
+
+    Small laptop speakers cannot reproduce low frequencies physically.
+    The bass enhancer generates upper harmonics of the bass content,
+    which the brain perceives as bass (the "missing fundamental" effect).
+
+    Scope is set to 2x the high-pass cutoff so harmonics are generated
+    only for frequencies the speaker rolls off.
+    """
+    scope = min(hp_freq * 2.0, 300.0)
+    return {
+        "bypass": False,
+        "input-gain": 0.0,
+        "output-gain": 0.0,
+        "amount": round(amount, 1),
+        "harmonics": 10.0,
+        "scope": round(scope, 1),
+        "floor": 10.0,
+        "blend": -10.0,
+        "floor-active": True,
+        "listen": False,
+    }
+
+
 def make_limiter():
     """Brickwall output limiter to catch any remaining overshoot.
 
@@ -1482,6 +1508,15 @@ def make_preset(kernel_name, peq_filters, vol_leveler=None,
             "plugins_order": ["convolver#0"],
         }
     }
+
+    # SoundWire speakers lack Dolby's proprietary Virtual Bass Enhancement
+    # (VBE) that runs in the Windows driver. Compensate with psychoacoustic
+    # harmonic generation so small speakers still produce perceived bass.
+    if is_soundwire:
+        hp_filters = [f for f in peq_filters if f["type"] in (7, 9)]
+        hp_freq = hp_filters[0]["f0"] if hp_filters else 100.0
+        preset["output"]["bass_enhancer#0"] = make_bass_enhancer(hp_freq)
+        preset["output"]["plugins_order"].append("bass_enhancer#0")
 
     # Stereo widening early in chain (before EQ changes the spectrum)
     st = make_stereo_tools(surround)

--- a/dolby_to_easyeffects.py
+++ b/dolby_to_easyeffects.py
@@ -33,9 +33,13 @@ from pathlib import Path
 import numpy as np
 from scipy.io import wavfile
 
-DEFAULT_OUTPUT_DIR = Path.home() / ".local" / "share" / "easyeffects" / "output"
-DEFAULT_IRS_DIR = Path.home() / ".local" / "share" / "easyeffects" / "irs"
-DEFAULT_AUTOLOAD_DIR = Path.home() / ".local" / "share" / "easyeffects" / "autoload" / "output"
+_FLATPAK_BASE = Path.home() / ".var" / "app" / "com.github.wwmm.easyeffects" / "config" / "easyeffects"
+_NATIVE_BASE = Path.home() / ".local" / "share" / "easyeffects"
+_EASYEFFECTS_BASE = _FLATPAK_BASE if _FLATPAK_BASE.exists() else _NATIVE_BASE
+
+DEFAULT_OUTPUT_DIR = _EASYEFFECTS_BASE / "output"
+DEFAULT_IRS_DIR = _EASYEFFECTS_BASE / "irs"
+DEFAULT_AUTOLOAD_DIR = _EASYEFFECTS_BASE / "autoload" / "output"
 
 SAMPLE_RATE = 48000
 FIR_LENGTH = 4096  # ~85ms, plenty for EQ

--- a/dolby_to_easyeffects.py
+++ b/dolby_to_easyeffects.py
@@ -98,16 +98,46 @@ def get_soundwire_ids():
     return results
 
 
+def _walk_to_pci_subsys(start: Path):
+    """Walk up sysfs from `start` to find the nearest PCI subsystem IDs."""
+    current = start.resolve()
+    while current != Path("/"):
+        subsys_vendor_path = current / "subsystem_vendor"
+        subsys_device_path = current / "subsystem_device"
+        if subsys_vendor_path.exists() and subsys_device_path.exists():
+            try:
+                vendor = subsys_vendor_path.read_text().strip()
+                device = subsys_device_path.read_text().strip()
+            except OSError:
+                pass
+            else:
+                vendor = vendor.replace("0x", "").upper()
+                device = device.replace("0x", "").upper()
+                if vendor and device:
+                    return (vendor, device)
+        current = current.parent
+    return None
+
+
 def get_pci_audio_subsystem():
     """Get the PCI subsystem ID of the audio controller.
 
     Returns (subsys_vendor, subsys_device) as uppercase 4-char hex strings,
     e.g. ("17AA", "2339"), or None if not found.
 
-    Walks up from the sound card device to find the PCI parent, which
-    handles both direct PCI sound devices and platform devices like
-    SOF SoundWire that sit under a PCI controller.
+    Prefers the PCI ancestor of a SoundWire device when present so we pick
+    the controller that actually hosts the speaker amplifiers, rather than
+    whichever /sys/class/sound card sorts first (which may be HDMI audio
+    on a discrete GPU). Falls back to walking up from sound cards for
+    traditional HDA systems.
     """
+    sdw_bus = Path("/sys/bus/soundwire/devices")
+    if sdw_bus.is_dir():
+        for dev_dir in sorted(sdw_bus.iterdir()):
+            result = _walk_to_pci_subsys(dev_dir)
+            if result:
+                return result
+
     pci_path = Path("/sys/class/sound")
     if not pci_path.is_dir():
         return None
@@ -115,23 +145,9 @@ def get_pci_audio_subsystem():
         device_link = card_dir / "device"
         if not device_link.exists():
             continue
-        # Walk up the sysfs tree to find a PCI device with subsystem IDs
-        current = device_link.resolve()
-        while current != Path("/"):
-            subsys_vendor_path = current / "subsystem_vendor"
-            subsys_device_path = current / "subsystem_device"
-            if subsys_vendor_path.exists() and subsys_device_path.exists():
-                try:
-                    vendor = subsys_vendor_path.read_text().strip()
-                    device = subsys_device_path.read_text().strip()
-                except OSError:
-                    pass
-                else:
-                    vendor = vendor.replace("0x", "").upper()
-                    device = device.replace("0x", "").upper()
-                    if vendor and device:
-                        return (vendor, device)
-            current = current.parent
+        result = _walk_to_pci_subsys(device_link)
+        if result:
+            return result
     return None
 
 
@@ -283,16 +299,17 @@ def _gather_speaker_info() -> SpeakerInfo:
     info.pci_subsystem = get_pci_audio_subsystem()
 
     # PCM playback devices
-    for pcm_dir in sorted(Path("/proc/asound/card0").glob("pcm*p")):
-        info_path = pcm_dir / "info"
-        if not info_path.exists():
-            continue
-        fields = {}
-        for line in info_path.read_text().splitlines():
-            if ": " in line:
-                k, v = line.split(": ", 1)
-                fields[k.strip()] = v.strip()
-        info.pcm_devices.append((fields.get("device", "?"), fields.get("id", "?")))
+    for card_dir in sorted(Path("/proc/asound").glob("card*")):
+        for pcm_dir in sorted(card_dir.glob("pcm*p")):
+            info_path = pcm_dir / "info"
+            if not info_path.exists():
+                continue
+            fields = {}
+            for line in info_path.read_text().splitlines():
+                if ": " in line:
+                    k, v = line.split(": ", 1)
+                    fields[k.strip()] = v.strip()
+            info.pcm_devices.append((fields.get("device", "?"), fields.get("id", "?")))
 
     # Speaker detection — branch by bus type
     if info.bus_type == "soundwire":
@@ -391,6 +408,11 @@ def find_tuning_xml(windows_root: Path):
     # SoundWire: build expected SUBSYS value from PCI subsystem ID.
     # Dolby filenames encode it as {pci_subsys_device}{pci_subsys_vendor},
     # e.g. PCI subsystem 17AA:2339 -> SUBSYS_233917AA
+    if sdw_devices and pci_subsys is None:
+        raise RuntimeError(
+            "SoundWire devices detected but could not determine PCI subsystem ID. "
+            "Cannot safely select a tuning XML."
+        )
     sdw_subsys_id = None
     if pci_subsys:
         vendor, device = pci_subsys
@@ -418,8 +440,8 @@ def find_tuning_xml(windows_root: Path):
     # Look for dax3_ext_*.inf_* directories
     candidates = []
     for dax_dir in sorted(driver_store.glob("dax3_ext_*.inf_*")):
-        for xml_file in sorted(dax_dir.glob("*.xml")):
-            if xml_file.name.endswith("_settings.xml"):
+        for xml_file in sorted(dax_dir.glob("*.[xX][mM][lL]")):
+            if xml_file.name.lower().endswith("_settings.xml"):
                 continue
             name = xml_file.name.upper()
 
@@ -441,10 +463,9 @@ def find_tuning_xml(windows_root: Path):
                 man = sdw_match.group(1)
                 func = sdw_match.group(2)
                 subsys = sdw_match.group(3)
-                if (man, func) in sdw_man_func:
-                    if sdw_subsys_id is None or subsys == sdw_subsys_id:
-                        candidates.append(xml_file)
-                        continue
+                if (man, func) in sdw_man_func and subsys == sdw_subsys_id:
+                    candidates.append(xml_file)
+                    continue
 
             # Match SDW_XXXX_SUBSYS_YYYYYYYY_... style
             sdw_alt = re.search(r"^SDW_[0-9A-F]+_SUBSYS_([0-9A-F]{8})", name)
@@ -1037,12 +1058,10 @@ def make_dialog_enhancer(dialog_enhancer, is_soundwire=False):
     amount = dialog_enhancer["amount"]
 
     if is_soundwire:
-        gain_presence = amount / 16.0 * 8.0
-        gain_clarity = gain_presence * 0.6
+        gain_presence = round(amount / 16.0 * 8.0, 2)
+        gain_clarity = round(gain_presence * 0.6, 2)
         if gain_presence <= 0:
             return None
-        band0 = make_band(2500.0, round(gain_presence, 2), q=0.7)
-        band1 = make_band(4000.0, round(gain_clarity, 2), q=1.0)
         return {
             "bypass": False,
             "input-gain": 0.0,
@@ -1050,15 +1069,19 @@ def make_dialog_enhancer(dialog_enhancer, is_soundwire=False):
             "mode": "IIR",
             "num-bands": 2,
             "split-channels": False,
-            "left": {"band0": band0, "band1": band1},
-            "right": {"band0": band0, "band1": band1},
+            "left": {
+                "band0": make_band(2500.0, gain_presence, q=0.7),
+                "band1": make_band(4000.0, gain_clarity, q=1.0),
+            },
+            "right": {
+                "band0": make_band(2500.0, gain_presence, q=0.7),
+                "band1": make_band(4000.0, gain_clarity, q=1.0),
+            },
         }
 
-    gain = amount / 16.0 * 6.0
+    gain = round(amount / 16.0 * 6.0, 2)
     if gain <= 0:
         return None
-
-    band = make_band(2500.0, round(gain, 2), q=0.7)
 
     return {
         "bypass": False,
@@ -1067,8 +1090,8 @@ def make_dialog_enhancer(dialog_enhancer, is_soundwire=False):
         "mode": "IIR",
         "num-bands": 1,
         "split-channels": False,
-        "left": {"band0": band},
-        "right": {"band0": band},
+        "left": {"band0": make_band(2500.0, gain, q=0.7)},
+        "right": {"band0": make_band(2500.0, gain, q=0.7)},
     }
 
 

--- a/dolby_to_easyeffects.py
+++ b/dolby_to_easyeffects.py
@@ -331,6 +331,27 @@ def write_autoload(autoload_dir: Path, device_name: str, device_description: str
     return path
 
 
+def resolve_xml_value(element, constants):
+    """Resolve a value from either a value= attribute or a preset= reference.
+
+    SoundWire XMLs (e.g. Lunar Lake) use preset references like
+    <ch_00 preset="array_20_zero" /> instead of inline value="..." attributes.
+    The preset name refers to a named element under <constant> whose target=
+    attribute holds the actual CSV data.
+    """
+    if element is None:
+        return ""
+    val = element.get("value")
+    if val is not None and val != "":
+        return val
+    preset_name = element.get("preset")
+    if preset_name and constants is not None:
+        ref = constants.find(preset_name)
+        if ref is not None:
+            return ref.get("target", "")
+    return ""
+
+
 def parse_xml(path: Path, endpoint_type="internal_speaker",
               operating_mode="normal", profile_type=None):
     tree = ET.parse(path)
@@ -378,8 +399,8 @@ def parse_xml(path: Path, endpoint_type="internal_speaker",
     vlldp = profile.find("tuning-vlldp")
 
     ao_bands = vlldp.find("audio-optimizer-bands")
-    ao_left = parse_csv_ints(ao_bands.find("ch_00").get("value"))
-    ao_right = parse_csv_ints(ao_bands.find("ch_01").get("value"))
+    ao_left = parse_csv_ints(resolve_xml_value(ao_bands.find("ch_00"), constant))
+    ao_right = parse_csv_ints(resolve_xml_value(ao_bands.find("ch_01"), constant))
 
     peq_filters = []
     peq_enable = vlldp.find("speaker-peq-enable")
@@ -469,15 +490,10 @@ def parse_xml(path: Path, endpoint_type="internal_speaker",
         if reg_tuning is not None:
             th_el = reg_tuning.find("threshold_high")
             tl_el = reg_tuning.find("threshold_low")
-            # Handle both inline values and presets (array_20_zero = all zeros)
-            if th_el is not None and th_el.get("value"):
-                th = [x / 16.0 for x in parse_csv_ints(th_el.get("value"))]
-            else:
-                th = [0.0] * 20
-            if tl_el is not None and tl_el.get("value"):
-                tl = [x / 16.0 for x in parse_csv_ints(tl_el.get("value"))]
-            else:
-                tl = [-12.0] * 20
+            th_val = resolve_xml_value(th_el, constant)
+            tl_val = resolve_xml_value(tl_el, constant)
+            th = [x / 16.0 for x in parse_csv_ints(th_val)] if th_val else [0.0] * 20
+            tl = [x / 16.0 for x in parse_csv_ints(tl_val)] if tl_val else [-12.0] * 20
             reg_stress = vlldp.find("regulator-stress-amount")
             stress = parse_csv_ints(reg_stress.get("value")) if reg_stress is not None else [0] * 8
             reg_slope = vlldp.find("regulator-distortion-slope")
@@ -542,12 +558,14 @@ def make_fir(band_freqs, gains_db, normalize=True):
     H_min = np.exp(log_H_min)
     fir = np.fft.irfft(H_min, n=n)
 
+    peak_mag = np.max(np.abs(H_min))
+    peak_db = 20.0 * np.log10(peak_mag + 1e-12)
+
     if normalize:
-        peak_mag = np.max(np.abs(H_min))
         if peak_mag > 0:
             fir /= peak_mag
 
-    return fir
+    return fir, peak_db
 
 
 def save_wav_stereo(path, fir_left, fir_right):
@@ -572,7 +590,7 @@ def make_band(freq: float, gain: float, q=1.5) -> dict:
     }
 
 
-def make_convolver(kernel_name: str):
+def make_convolver(kernel_name: str, output_gain: float = 0.0):
     """Convolver plugin config referencing an IR by name.
 
     EasyEffects 8.x uses kernel-name (filename stem without extension),
@@ -581,7 +599,7 @@ def make_convolver(kernel_name: str):
     return {
         "bypass": False,
         "input-gain": 0.0,
-        "output-gain": 0.0,
+        "output-gain": round(output_gain, 2),
         "kernel-name": kernel_name,
         "ir-width": 100,
         "autogain": False,
@@ -759,7 +777,7 @@ def make_stereo_tools(surround):
     }
 
 
-def make_dialog_enhancer(dialog_enhancer):
+def make_dialog_enhancer(dialog_enhancer, is_soundwire=False):
     """Dialog enhancer mapped as a broad speech-band EQ boost.
 
     Dolby's dialog enhancer (DE) isolates speech frequencies and
@@ -767,14 +785,34 @@ def make_dialog_enhancer(dialog_enhancer):
     filter centered at 2.5 kHz (speech presence region), with gain
     scaled by the DE amount (0-16 scale).
 
-    The DE amount maps to gain: amount/16 * 6 dB, giving a maximum
-    of +6 dB at amount=16. Typical values: dynamic=5 (+1.9 dB),
-    voice=3 (+1.1 dB), music=7 (+2.6 dB when enabled).
+    For HDA presets: amount/16 * 6 dB, giving a maximum of +6 dB.
+    For SoundWire presets: stronger mapping (amount/16 * 8 dB) plus
+    a second bell at 4 kHz for consonant clarity, compensating for
+    the simpler full-range speakers on newer platforms.
     """
     if not dialog_enhancer:
         return None
 
     amount = dialog_enhancer["amount"]
+
+    if is_soundwire:
+        gain_presence = amount / 16.0 * 8.0
+        gain_clarity = gain_presence * 0.6
+        if gain_presence <= 0:
+            return None
+        band0 = make_band(2500.0, round(gain_presence, 2), q=0.7)
+        band1 = make_band(4000.0, round(gain_clarity, 2), q=1.0)
+        return {
+            "bypass": False,
+            "input-gain": 0.0,
+            "output-gain": 0.0,
+            "mode": "IIR",
+            "num-bands": 2,
+            "split-channels": False,
+            "left": {"band0": band0, "band1": band1},
+            "right": {"band0": band0, "band1": band1},
+        }
+
     gain = amount / 16.0 * 6.0
     if gain <= 0:
         return None
@@ -793,7 +831,7 @@ def make_dialog_enhancer(dialog_enhancer):
     }
 
 
-def make_autogain(vol_leveler):
+def make_autogain(vol_leveler, conservative=False):
     """Autogain plugin mapping from Dolby volume leveler.
 
     The Dolby volume leveler brings quiet passages up to a target loudness.
@@ -803,27 +841,33 @@ def make_autogain(vol_leveler):
       0 = gentle (long history window)
       10 = aggressive (short history window)
 
-    Bypassed by default: without Dolby's MI (Media Intelligence) steering,
-    the autogain causes audible distortion on quiet→loud transitions
-    because the convolver's steep spectral shape creates ~10 dB of
-    peak-to-LUFS mismatch that MI would normally compensate for.
+    For HDA presets: bypassed by default because the convolver's steep
+    spectral shape (IEQ + audio-optimizer) creates ~10 dB peak-to-LUFS
+    mismatch that causes distortion without Dolby's MI steering.
+
+    For SoundWire presets (conservative=True): enabled with gentle settings.
+    The simpler spectral shape (IEQ only, no AO correction) has much less
+    peak-to-LUFS mismatch, so conservative autogain is safe.
     """
     if not vol_leveler or not vol_leveler["enable"]:
         return None
 
     amount = vol_leveler["amount"]
-
-    # Map Dolby amount (0-10) to maximum-history (seconds).
-    # Higher amount = shorter window = more aggressive leveling.
-    # amount 0 → 30s (gentle), amount 4+ → 10s (aggressive, clamped)
-    max_history = max(30 - amount * 5, 10)
-
-    # Dolby target is in dBFS; map directly to LUFS target.
     target = vol_leveler["out_target"]
 
-    # Bypassed by default: without Dolby's MI (Media Intelligence) steering,
-    # the autogain causes audible distortion on quiet→loud transitions.
-    # Settings are preserved so users can enable it manually if desired.
+    if conservative:
+        max_history = max(40 - amount * 4, 15)
+        return {
+            "bypass": False,
+            "input-gain": 0.0,
+            "output-gain": 0.0,
+            "maximum-history": max_history,
+            "reference": "Geometric Mean (MSI)",
+            "silence-threshold": -50.0,
+            "target": round(target - 6.0, 1),
+        }
+
+    max_history = max(30 - amount * 5, 10)
     return {
         "bypass": True,
         "input-gain": 0.0,
@@ -1193,11 +1237,12 @@ def make_limiter():
 
 def make_preset(kernel_name, peq_filters, vol_leveler=None,
                 dialog_enhancer=None, surround=None, mb_comp=None,
-                regulator=None, freqs=None):
+                regulator=None, freqs=None, convolver_gain=0.0,
+                is_soundwire=False):
     preset = {
         "output": {
             "blocklist": [],
-            "convolver#0": make_convolver(kernel_name),
+            "convolver#0": make_convolver(kernel_name, output_gain=convolver_gain),
             "plugins_order": ["convolver#0"],
         }
     }
@@ -1215,7 +1260,7 @@ def make_preset(kernel_name, peq_filters, vol_leveler=None,
 
     # Dialog enhancer (speech presence boost) before the volume leveler,
     # matching Dolby's CP order: DE → IEQ → Volume Leveler.
-    de = make_dialog_enhancer(dialog_enhancer)
+    de = make_dialog_enhancer(dialog_enhancer, is_soundwire=is_soundwire)
     if de:
         preset["output"]["equalizer#1"] = de
         preset["output"]["plugins_order"].append("equalizer#1")
@@ -1223,7 +1268,7 @@ def make_preset(kernel_name, peq_filters, vol_leveler=None,
     # Autogain (volume leveler) goes before the compressor/regulator to match
     # Dolby's signal flow: CP (volume leveler) → VLLDP (compressor → regulator).
     # This lets the compressor and regulator catch any overshoot from the leveler.
-    autogain = make_autogain(vol_leveler)
+    autogain = make_autogain(vol_leveler, conservative=is_soundwire)
     if autogain:
         preset["output"]["autogain#0"] = autogain
         preset["output"]["plugins_order"].append("autogain#0")
@@ -1336,6 +1381,9 @@ def main():
     else:
         parser.error("either xml_file or --windows is required")
 
+    xml_basename = Path(xml_path).name.upper()
+    is_soundwire = "SOUNDWIRE" in xml_basename or xml_basename.startswith("SDW_")
+
     if args.list:
         print(f"Endpoints and profiles in {xml_path}:")
         list_endpoints(xml_path)
@@ -1367,6 +1415,8 @@ def main():
         name_base = "-".join(name_parts)
 
         print(f"\n{'='*60}")
+        if is_soundwire:
+            print(f"SoundWire device detected — using enhanced preset generation")
         print(f"Endpoint: {args.endpoint} (mode={args.mode})")
         print(f"Profile: {profile_type or '(first)'}")
 
@@ -1460,15 +1510,26 @@ def main():
             combined_right = ieq_db + ao_db_right
 
             # Generate FIR impulse responses
-            fir_left = make_fir(float_freqs, combined_left, normalize=True)
-            fir_right = make_fir(float_freqs, combined_right, normalize=True)
+            fir_left, peak_db_left = make_fir(float_freqs, combined_left, normalize=True)
+            fir_right, peak_db_right = make_fir(float_freqs, combined_right, normalize=True)
+            peak_db = max(peak_db_left, peak_db_right)
+
+            # For SoundWire presets, restore half the headroom that peak
+            # normalization removed. The IEQ-only curve (no AO correction)
+            # peaks at low-mids; normalizing to that peak pushes presence
+            # and treble below their intended level. Restoring 50% keeps
+            # the spectral shape while recovering perceived brightness.
+            convolver_gain = peak_db * 0.5 if is_soundwire else 0.0
 
             # Save stereo impulse response
             irs_path = args.irs_dir / f"{preset_name}.irs"
             save_wav_stereo(irs_path, fir_left, fir_right)
 
             # Create preset (kernel-name is the WAV filename stem)
-            preset = make_preset(preset_name, peq_filters, vol_leveler, dialog_enhancer, surround, mb_comp, regulator, freqs)
+            preset = make_preset(preset_name, peq_filters, vol_leveler,
+                                 dialog_enhancer, surround, mb_comp, regulator,
+                                 freqs, convolver_gain=convolver_gain,
+                                 is_soundwire=is_soundwire)
             out_path = args.output_dir / f"{preset_name}.json"
             out_path.write_text(json.dumps(preset, indent=4) + "\n")
 
@@ -1476,6 +1537,9 @@ def main():
 
             print(f"Wrote {irs_path}")
             print(f"Wrote {out_path}")
+            if convolver_gain != 0.0:
+                print(f"  Convolver output-gain: {convolver_gain:+.1f} dB "
+                      f"(FIR peak was {peak_db:+.1f} dB, restoring 50%)")
             print(f"  {curve_key} combined IEQ+AO curve (left channel):")
             print(f"  {'freq':>8}  {'IEQ':>6}  {'AO':>6}  {'combined':>8}")
             for i, f in enumerate(freqs):

--- a/dolby_to_easyeffects.py
+++ b/dolby_to_easyeffects.py
@@ -43,7 +43,7 @@ def parse_csv_ints(s: str) -> list[int]:
     return [int(x) for x in s.split(",")]
 
 
-def get_audio_subsystem_ids():
+def get_hda_codec_ids():
     """Read HDA codec subsystem IDs from /proc/asound.
 
     Returns a list of (vendor_id, subsystem_id) tuples as uppercase hex
@@ -67,51 +67,158 @@ def get_audio_subsystem_ids():
     return results
 
 
+def get_soundwire_ids():
+    """Read SoundWire device IDs from /sys/bus/soundwire/devices.
+
+    Returns a list of (manufacturer_id, part_id) tuples as uppercase hex
+    strings, e.g. [("025D", "1318")].
+    """
+    results = []
+    sdw_path = Path("/sys/bus/soundwire/devices")
+    if not sdw_path.is_dir():
+        return results
+    for dev_dir in sorted(sdw_path.iterdir()):
+        # SoundWire slave devices look like "sdw:L:N:MMMM:PPPP:VV"
+        match = re.match(
+            r"sdw:\d+:\d+:([0-9a-fA-F]{4}):([0-9a-fA-F]{4}):\d+", dev_dir.name
+        )
+        if match:
+            man_id = match.group(1).upper()
+            part_id = match.group(2).upper()
+            results.append((man_id, part_id))
+    return results
+
+
+def get_pci_audio_subsystem():
+    """Get the PCI subsystem ID of the audio controller.
+
+    Returns (subsys_vendor, subsys_device) as uppercase 4-char hex strings,
+    e.g. ("17AA", "2339"), or None if not found.
+
+    Walks up from the sound card device to find the PCI parent, which
+    handles both direct PCI sound devices and platform devices like
+    SOF SoundWire that sit under a PCI controller.
+    """
+    pci_path = Path("/sys/class/sound")
+    if not pci_path.is_dir():
+        return None
+    for card_dir in sorted(pci_path.glob("card*")):
+        device_link = card_dir / "device"
+        if not device_link.exists():
+            continue
+        # Walk up the sysfs tree to find a PCI device with subsystem IDs
+        current = device_link.resolve()
+        while current != Path("/"):
+            subsys_vendor_path = current / "subsystem_vendor"
+            subsys_device_path = current / "subsystem_device"
+            if subsys_vendor_path.exists() and subsys_device_path.exists():
+                try:
+                    vendor = subsys_vendor_path.read_text().strip()
+                    device = subsys_device_path.read_text().strip()
+                except OSError:
+                    pass
+                else:
+                    vendor = vendor.replace("0x", "").upper()
+                    device = device.replace("0x", "").upper()
+                    if vendor and device:
+                        return (vendor, device)
+            current = current.parent
+    return None
+
+
 def find_tuning_xml(windows_root: Path):
     """Find the DAX3 tuning XML matching this machine's audio hardware.
 
     Searches the Windows DriverStore for DAX3 tuning XMLs and matches
-    against the audio codec's subsystem ID from /proc/asound.
+    against:
+    - HDA codec subsystem IDs from /proc/asound (traditional HDA codecs)
+    - SoundWire device IDs + PCI subsystem ID (newer Intel platforms)
     """
-    codecs = get_audio_subsystem_ids()
-    if not codecs:
+    hda_codecs = get_hda_codec_ids()
+    sdw_devices = get_soundwire_ids()
+    pci_subsys = get_pci_audio_subsystem()
+
+    if not hda_codecs and not sdw_devices:
         raise FileNotFoundError(
-            "No HDA codecs found in /proc/asound. "
+            "No HDA codecs or SoundWire devices found. "
             "Cannot auto-detect audio hardware."
         )
 
-    # Extract just the subsystem IDs for matching
-    subsys_ids = {s.upper() for _, s in codecs}
+    # HDA subsystem IDs for matching DEV_*_SUBSYS_*.xml files
+    hda_subsys_ids = {s.upper() for _, s in hda_codecs}
 
-    # Search DriverStore for DAX3 tuning XMLs
-    driver_store = windows_root / "System32" / "DriverStore" / "FileRepository"
-    if not driver_store.is_dir():
+    # SoundWire: build expected SUBSYS value from PCI subsystem ID.
+    # Dolby filenames encode it as {pci_subsys_device}{pci_subsys_vendor},
+    # e.g. PCI subsystem 17AA:2339 -> SUBSYS_233917AA
+    sdw_subsys_id = None
+    if pci_subsys:
+        vendor, device = pci_subsys
+        sdw_subsys_id = f"{device}{vendor}".upper()
+
+    # SoundWire manufacturer+function pairs for matching
+    sdw_man_func = {(m.upper(), p.upper()) for m, p in sdw_devices}
+
+    # Search DriverStore for DAX3 tuning XMLs.
+    # Accept either a Windows system root (needs the FileRepository subpath)
+    # or an already-extracted DriverStore directory containing dax3_ext_*.inf_*
+    # subdirectories directly.
+    file_repo = windows_root / "System32" / "DriverStore" / "FileRepository"
+    if file_repo.is_dir():
+        driver_store = file_repo
+    elif windows_root.is_dir() and any(windows_root.glob("dax3_ext_*.inf_*")):
+        driver_store = windows_root
+    else:
         raise FileNotFoundError(
-            f"DriverStore not found at {driver_store}. "
-            f"Is '{windows_root}' the correct Windows directory?"
+            f"DriverStore not found at {file_repo} and {windows_root} does not "
+            f"contain dax3_ext_*.inf_* subdirectories. "
+            f"Pass either a Windows system root or an extracted DriverStore."
         )
 
     # Look for dax3_ext_*.inf_* directories
     candidates = []
     for dax_dir in sorted(driver_store.glob("dax3_ext_*.inf_*")):
-        for xml_file in sorted(dax_dir.glob("DEV_*_SUBSYS_*.xml")):
-            # Skip settings files
+        for xml_file in sorted(dax_dir.glob("*.xml")):
             if xml_file.name.endswith("_settings.xml"):
                 continue
-            # Extract subsystem ID from filename: DEV_XXXX_SUBSYS_YYYYYYYY_...
-            match = re.search(r"SUBSYS_([0-9A-Fa-f]{8})", xml_file.name)
-            if match:
-                file_subsys = match.group(1).upper()
-                if file_subsys in subsys_ids:
+            name = xml_file.name.upper()
+
+            # Match HDA-style: DEV_XXXX_SUBSYS_YYYYYYYY_...
+            # Also matches INTELAUDIO_DEV_... variants
+            if "DEV_" in name and "SUBSYS_" in name:
+                match = re.search(r"SUBSYS_([0-9A-F]{8})", name)
+                if match and match.group(1) in hda_subsys_ids:
                     candidates.append(xml_file)
+                    continue
+
+            # Match SoundWire-style: SOUNDWIRE_MAN_XXXX_FUNC_YYYY_SUBSYS_ZZZZZZZZ
+            # or SOUNDWIRE_SDCAFUNCTION_NN_MAN_XXXX_FUNC_YYYY_SUBSYS_ZZZZZZZZ
+            sdw_match = re.search(
+                r"MAN_([0-9A-F]{4})_FUNC_([0-9A-F]{4})_SUBSYS_([0-9A-F]{8})",
+                name,
+            )
+            if sdw_match:
+                man = sdw_match.group(1)
+                func = sdw_match.group(2)
+                subsys = sdw_match.group(3)
+                if (man, func) in sdw_man_func:
+                    if sdw_subsys_id is None or subsys == sdw_subsys_id:
+                        candidates.append(xml_file)
+                        continue
+
+            # Match SDW_XXXX_SUBSYS_YYYYYYYY_... style
+            sdw_alt = re.search(r"^SDW_[0-9A-F]+_SUBSYS_([0-9A-F]{8})", name)
+            if sdw_alt and sdw_subsys_id and sdw_alt.group(1) == sdw_subsys_id:
+                candidates.append(xml_file)
+                continue
 
     if not candidates:
-        codec_info = ", ".join(
-            f"vendor={v} subsys={s}" for v, s in codecs
-        )
+        hda_info = ", ".join(f"vendor={v} subsys={s}" for v, s in hda_codecs)
+        sdw_info = ", ".join(f"man={m} part={p}" for m, p in sdw_devices)
+        pci_info = f"pci_subsys={pci_subsys}" if pci_subsys else "no PCI subsystem"
         raise FileNotFoundError(
             f"No matching DAX3 tuning XML found in {driver_store}. "
-            f"Detected codecs: {codec_info}"
+            f"Detected HDA codecs: {hda_info or 'none'}; "
+            f"SoundWire devices: {sdw_info or 'none'}; {pci_info}"
         )
 
     if len(candidates) > 1:
@@ -136,6 +243,8 @@ def find_tuning_xml(windows_root: Path):
                 ver = "?"
             marker = "→ " if c == candidates[0] else "  "
             print(f"  {marker}{c} (tuning_version={ver})")
+    else:
+        print(f"Matched tuning XML: {candidates[0]}")
 
     return candidates[0]
 

--- a/dolby_to_easyeffects.py
+++ b/dolby_to_easyeffects.py
@@ -26,6 +26,7 @@ import math
 import re
 import subprocess
 import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import numpy as np
@@ -44,10 +45,10 @@ def parse_csv_ints(s: str) -> list[int]:
 
 
 def get_hda_codec_ids():
-    """Read HDA codec subsystem IDs from /proc/asound.
+    """Read HDA codec names and subsystem IDs from /proc/asound.
 
-    Returns a list of (vendor_id, subsystem_id) tuples as uppercase hex
-    strings, e.g. [("10EC0287", "17AA22E6")].
+    Returns a list of (vendor_id, subsystem_id, codec_name) tuples, e.g.
+    [("10EC0287", "17AA22E6", "Realtek ALC287")].
     """
     results = []
     for codec_path in sorted(Path("/proc/asound").glob("card*/codec*")):
@@ -55,15 +56,18 @@ def get_hda_codec_ids():
             text = codec_path.read_text()
         except OSError:
             continue
+        codec_name = ""
         vendor_id = None
         subsys_id = None
         for line in text.splitlines():
-            if line.startswith("Vendor Id:"):
+            if line.startswith("Codec:"):
+                codec_name = line.split(":", 1)[1].strip()
+            elif line.startswith("Vendor Id:"):
                 vendor_id = line.split("0x", 1)[-1].strip().upper()
             elif line.startswith("Subsystem Id:"):
                 subsys_id = line.split("0x", 1)[-1].strip().upper()
         if vendor_id and subsys_id:
-            results.append((vendor_id, subsys_id))
+            results.append((vendor_id, subsys_id, codec_name))
     return results
 
 
@@ -126,131 +130,236 @@ def get_pci_audio_subsystem():
     return None
 
 
-def report_speaker_info():
-    """Report detected audio hardware and speaker layout."""
-    import platform
+@dataclass
+class SpeakerPin:
+    """A single internal speaker output (HDA pin or SoundWire amplifier)."""
+    node: str            # HDA node ID or SoundWire device name
+    control_name: str    # ALSA control name or driver name
+    role: str            # "woofer" or "tweeter"
+    stereo: bool = True
 
-    print("=== System ===")
-    dmi_product = Path("/sys/class/dmi/id/product_name")
-    dmi_family = Path("/sys/class/dmi/id/product_family")
-    if dmi_product.exists():
-        print(f"  Product: {dmi_product.read_text().strip()}")
-    if dmi_family.exists():
-        print(f"  Family:  {dmi_family.read_text().strip()}")
-    print(f"  Kernel:  {platform.release()}")
 
-    print("\n=== Sound cards ===")
-    cards_path = Path("/proc/asound/cards")
-    if cards_path.exists():
-        for line in cards_path.read_text().strip().splitlines():
-            print(f"  {line.strip()}")
-    else:
-        print("  (none found)")
+@dataclass
+class SpeakerInfo:
+    """Collected audio hardware information for --speaker-info."""
+    product: str = ""
+    family: str = ""
+    kernel: str = ""
+    sound_cards: list[str] = field(default_factory=list)
+    hda_codecs: list[tuple[str, str, str]] = field(default_factory=list)
+    soundwire_devices: list[tuple[str, str]] = field(default_factory=list)
+    pci_subsystem: tuple[str, str] | None = None
+    pcm_devices: list[tuple[str, str]] = field(default_factory=list)
+    # SoundWire-specific
+    sdw_codecs: list[str] = field(default_factory=list)
+    sdw_amplifiers: list[str] = field(default_factory=list)
+    # Speaker pins (HDA or SoundWire)
+    speakers: list[SpeakerPin] = field(default_factory=list)
 
-    print("\n=== HDA codecs ===")
-    hda = get_hda_codec_ids()
-    if hda:
-        for vendor_id, subsys_id in hda:
-            print(f"  Vendor: 0x{vendor_id}  Subsystem: 0x{subsys_id}")
-    else:
-        print("  (none)")
+    @property
+    def bus_type(self) -> str:
+        if self.soundwire_devices:
+            return "soundwire"
+        if self.hda_codecs:
+            return "hda"
+        return "unknown"
 
-    print("\n=== SoundWire devices ===")
+    @property
+    def layout_summary(self) -> str:
+        if not self.speakers:
+            return "Could not determine speaker layout"
+        total = sum(2 if s.stereo else 1 for s in self.speakers)
+        by_role: dict[str, int] = {}
+        for s in self.speakers:
+            by_role[s.role] = by_role.get(s.role, 0) + (2 if s.stereo else 1)
+        if len(self.speakers) == 1:
+            return f"{total} speakers → full-range stereo"
+        parts = " + ".join(f"{n}x {role}" for role, n in by_role.items())
+        return f"{total} speakers → multi-way: {parts}"
+
+
+def _detect_soundwire_speakers(info: SpeakerInfo):
+    """Detect speaker amplifiers on the SoundWire bus."""
     sdw_path = Path("/sys/bus/soundwire/devices")
-    sdw = get_soundwire_ids()
-    if sdw:
-        for man_id, part_id in sdw:
-            print(f"  Manufacturer: 0x{man_id}  Part: 0x{part_id}")
-    else:
-        print("  (none)")
+    if not sdw_path.is_dir():
+        return
 
-    print("\n=== PCI audio subsystem ===")
-    pci = get_pci_audio_subsystem()
-    if pci:
-        print(f"  Subsystem: {pci[0]}:{pci[1]}")
-    else:
-        print("  (none)")
+    amp_patterns = ("rt13", "rt_amp", "max98", "cs35")
 
-    print("\n=== Speaker amplifiers ===")
-    amp_count = 0
-    amp_names = []
-    if sdw_path.is_dir():
-        for dev_dir in sorted(sdw_path.iterdir()):
-            match = re.match(
-                r"sdw:\d+:\d+:([0-9a-fA-F]{4}):([0-9a-fA-F]{4}):\d+",
-                dev_dir.name,
-            )
-            if not match:
-                continue
-            part_id = match.group(2).upper()
-            driver_link = dev_dir / "driver"
-            driver_name = ""
-            if driver_link.is_symlink():
-                driver_name = driver_link.resolve().name
-            # Speaker amplifier codecs (Realtek RT1316/RT1318/RT1320 etc.)
-            # are distinguishable from CODEC devices (RT711/RT712/RT713)
-            # by their part ID range or driver name.
-            is_amp = (
-                "rt13" in driver_name.lower()
-                or "rt_amp" in driver_name.lower()
-                or "max98" in driver_name.lower()
-                or "cs35" in driver_name.lower()
-            )
-            if is_amp:
-                amp_count += 1
-                amp_names.append(f"{dev_dir.name} (driver: {driver_name})")
-            else:
-                print(f"  Codec: {dev_dir.name} (driver: {driver_name})")
+    for dev_dir in sorted(sdw_path.iterdir()):
+        match = re.match(
+            r"sdw:\d+:\d+:([0-9a-fA-F]{4}):([0-9a-fA-F]{4}):\d+",
+            dev_dir.name,
+        )
+        if not match:
+            continue
+        driver_link = dev_dir / "driver"
+        driver_name = driver_link.resolve().name if driver_link.is_symlink() else ""
+        lower_driver = driver_name.lower()
 
-    # Also check ALSA mixer for speaker amp controls
-    alsa_amps = set()
+        if any(p in lower_driver for p in amp_patterns):
+            info.sdw_amplifiers.append(f"{dev_dir.name} (driver: {driver_name})")
+            info.speakers.append(SpeakerPin(
+                node=dev_dir.name,
+                control_name=driver_name,
+                role="amplifier",
+            ))
+        else:
+            info.sdw_codecs.append(f"{dev_dir.name} (driver: {driver_name})")
+
+    if info.speakers:
+        return
+
+    # Fallback: check ALSA mixer for amp controls when sysfs gives nothing
     try:
         result = subprocess.run(
             ["amixer", "-c0", "scontrols"],
             capture_output=True, text=True, timeout=5,
         )
         for line in result.stdout.splitlines():
-            # e.g. "Simple mixer control 'rt1318-1 DAC',0"
             m = re.search(r"'(rt\d+[^']*|max98[^']*|cs35[^']*)\s+DAC'", line, re.I)
             if m:
-                alsa_amps.add(m.group(1))
+                name = m.group(1)
+                info.sdw_amplifiers.append(f"{name} (from ALSA mixer)")
+                info.speakers.append(SpeakerPin(
+                    node="mixer", control_name=name, role="amplifier",
+                ))
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
 
-    if amp_names:
-        for name in amp_names:
-            print(f"  Amplifier: {name}")
-    elif alsa_amps:
-        for name in sorted(alsa_amps):
-            print(f"  Amplifier: {name} (from ALSA mixer)")
-        amp_count = len(alsa_amps)
 
-    if amp_count == 0:
-        print("  (no speaker amplifiers detected)")
+def _detect_hda_speakers(info: SpeakerInfo):
+    """Detect internal speakers from HDA codec pin configurations."""
+    for codec_path in sorted(Path("/proc/asound").glob("card*/codec*")):
+        try:
+            text = codec_path.read_text()
+        except OSError:
+            continue
+        nodes = re.split(r"(?=^Node 0x[0-9a-fA-F]+ )", text, flags=re.MULTILINE)
+        for block in nodes:
+            if "[Pin Complex]" not in block or "[Fixed] Speaker at Int" not in block:
+                continue
+            node_match = re.match(r"Node (0x[0-9a-fA-F]+)", block)
+            if not node_match:
+                continue
+            ctrl_match = re.search(r'Control: name="([^"]+)"', block)
+            ctrl_name = ctrl_match.group(1) if ctrl_match else "Speaker"
+            lower = ctrl_name.lower()
+            role = "woofer" if ("bass" in lower or "woofer" in lower) else "tweeter"
+            info.speakers.append(SpeakerPin(
+                node=node_match.group(1),
+                control_name=ctrl_name,
+                role=role,
+                stereo="Stereo" in block.split("\n", 1)[0],
+            ))
 
-    print("\n=== PCM playback devices ===")
+
+def _gather_speaker_info() -> SpeakerInfo:
+    """Collect all audio hardware information into a SpeakerInfo."""
+    import platform
+
+    info = SpeakerInfo(kernel=platform.release())
+
+    # System identity
+    for attr, path in [("product", "/sys/class/dmi/id/product_name"),
+                       ("family", "/sys/class/dmi/id/product_family")]:
+        p = Path(path)
+        if p.exists():
+            setattr(info, attr, p.read_text().strip())
+
+    # Sound cards
+    cards_path = Path("/proc/asound/cards")
+    if cards_path.exists():
+        info.sound_cards = [l.strip() for l in cards_path.read_text().strip().splitlines()]
+
+    # Bus-agnostic detection
+    info.hda_codecs = get_hda_codec_ids()
+    info.soundwire_devices = get_soundwire_ids()
+    info.pci_subsystem = get_pci_audio_subsystem()
+
+    # PCM playback devices
     for pcm_dir in sorted(Path("/proc/asound/card0").glob("pcm*p")):
         info_path = pcm_dir / "info"
         if not info_path.exists():
             continue
-        info = {}
+        fields = {}
         for line in info_path.read_text().splitlines():
             if ": " in line:
                 k, v = line.split(": ", 1)
-                info[k.strip()] = v.strip()
-        stream_id = info.get("id", "?")
-        print(f"  pcm{info.get('device', '?')}p: {stream_id}")
+                fields[k.strip()] = v.strip()
+        info.pcm_devices.append((fields.get("device", "?"), fields.get("id", "?")))
 
-    print("\n=== Speaker layout estimate ===")
-    if amp_count >= 2:
-        print(f"  {amp_count} amplifiers detected → likely multi-way "
-              f"(woofer + tweeter) or multi-driver setup")
-    elif amp_count == 1:
-        print(f"  1 amplifier detected → likely full-range speakers (no dedicated tweeters)")
-    else:
-        print(f"  Could not determine speaker layout (no SoundWire amplifiers found)")
-        if hda:
-            print(f"  HDA codec detected — speaker layout not discoverable via sysfs")
+    # Speaker detection — branch by bus type
+    if info.bus_type == "soundwire":
+        _detect_soundwire_speakers(info)
+    elif info.bus_type == "hda":
+        _detect_hda_speakers(info)
+
+    return info
+
+
+def _print_speaker_info(info: SpeakerInfo):
+    """Print the collected speaker info report."""
+    sections = []
+
+    # System
+    lines = []
+    if info.product:
+        lines.append(f"  Product: {info.product}")
+    if info.family:
+        lines.append(f"  Family:  {info.family}")
+    lines.append(f"  Kernel:  {info.kernel}")
+    sections.append(("System", lines))
+
+    # Sound cards
+    sections.append(("Sound cards",
+                      [f"  {c}" for c in info.sound_cards] or ["  (none found)"]))
+
+    # HDA codecs
+    sections.append(("HDA codecs",
+                      [f"  {name or 'Unknown'} — Vendor: 0x{v}  Subsystem: 0x{s}"
+                       for v, s, name in info.hda_codecs]
+                      or ["  (none)"]))
+
+    # SoundWire devices
+    sections.append(("SoundWire devices",
+                      [f"  Manufacturer: 0x{m}  Part: 0x{p}" for m, p in info.soundwire_devices]
+                      or ["  (none)"]))
+
+    # PCI audio subsystem
+    pci_line = f"  Subsystem: {info.pci_subsystem[0]}:{info.pci_subsystem[1]}" if info.pci_subsystem else "  (none)"
+    sections.append(("PCI audio subsystem", [pci_line]))
+
+    # Speaker amplifiers / HDA pins (bus-specific section)
+    if info.bus_type == "soundwire":
+        amp_lines = [f"  Codec: {c}" for c in info.sdw_codecs]
+        amp_lines += [f"  Amplifier: {a}" for a in info.sdw_amplifiers]
+        if not info.sdw_amplifiers:
+            amp_lines.append("  (no speaker amplifiers detected)")
+        sections.append(("Speaker amplifiers", amp_lines))
+    elif info.bus_type == "hda" and info.speakers:
+        sections.append(("HDA internal speakers", [
+            f"  {s.node}: {s.control_name} ({s.role}, {'stereo' if s.stereo else 'mono'})"
+            for s in info.speakers
+        ]))
+
+    # PCM playback devices
+    sections.append(("PCM playback devices",
+                      [f"  pcm{dev}p: {name}" for dev, name in info.pcm_devices]))
+
+    # Speaker layout estimate
+    sections.append(("Speaker layout estimate", [f"  {info.layout_summary}"]))
+
+    for title, lines in sections:
+        print(f"=== {title} ===")
+        print("\n".join(lines))
+        print()
+
+
+def report_speaker_info():
+    """Report detected audio hardware and speaker layout."""
+    info = _gather_speaker_info()
+    _print_speaker_info(info)
 
 
 def find_tuning_xml(windows_root: Path):
@@ -272,7 +381,7 @@ def find_tuning_xml(windows_root: Path):
         )
 
     # HDA subsystem IDs for matching DEV_*_SUBSYS_*.xml files
-    hda_subsys_ids = {s.upper() for _, s in hda_codecs}
+    hda_subsys_ids = {s.upper() for _, s, _name in hda_codecs}
 
     # SoundWire: build expected SUBSYS value from PCI subsystem ID.
     # Dolby filenames encode it as {pci_subsys_device}{pci_subsys_vendor},


### PR DESCRIPTION

### Summary
- Add support for Intel SoundWire-based audio platforms (Lunar Lake, Meteor Lake, some Tiger/Alder Lake SKUs) alongside existing HDA support
- Add `--speaker-info` diagnostic flag to report detected audio hardware and speaker layout
- Add psychoacoustic bass enhancer for SoundWire presets, based on the [EasyEffects laptop speaker guide](https://wwmm.github.io/easyeffects/guides/guide_1.html)
- Fix XML parsing crash for SoundWire tuning files that use `preset="..."` references instead of inline `value="..."` attributes

### What changed

**SoundWire auto-detection and preset generation:**
- Detect SoundWire device IDs from `/sys/bus/soundwire/devices/` and PCI audio subsystem from sysfs
- Match against `SOUNDWIRE_MAN_*_FUNC_*_SUBSYS_*.xml` and `SDW_*_SUBSYS_*.xml` filename patterns from the Dolby driver
- `--windows` now also accepts an already-extracted DriverStore directory
- `resolve_xml_value()` handles SoundWire XMLs that reference preset arrays instead of inline values

**HDA vs SoundWire preset differences:**

| Aspect | HDA | SoundWire |
|--------|-----|-----------|
| Bass enhancer | Not added | Psychoacoustic harmonic generation |
| Dialog enhancer | Single bell at 2.5 kHz | Dual bells: 2.5 kHz + 4 kHz |
| Convolver output-gain | 0.0 dB | +50% of FIR peak (recovers brightness after normalization) |
| Autogain | Bypassed | Enabled with conservative settings |

**`--speaker-info` diagnostics:**
- Reports system identity, sound cards, HDA codecs, SoundWire devices, PCI subsystem, PCM devices, and estimated speaker layout
- Detects speaker amplifier count/type and estimates multi-way layout (woofer + tweeter vs full-range): 
  - ThinkPad X1 Yoga Gen 7: Stereo speakers, 2W x2 woofers and 0.8W x2 tweeters, Dolby Atmos
  - ThinkPad X1 Carbon Gen 13: Stereo speakers, 2W x2, Dolby Atmos
- Useful for users to verify hardware detection before generating presets

**Psychoacoustic bass enhancer (SoundWire only):**
- Compensates for Dolby's proprietary Virtual Bass Enhancement (VBE) that only runs in the Windows driver
- Uses harmonic generation to create perceived bass on small speakers via the missing fundamental effect
- Approach follows the [EasyEffects laptop speaker guide](https://wwmm.github.io/easyeffects/guides/guide_1.html)

**README updates:**
- Document SoundWire support and filename patterns
- Add Flatpak EasyEffects section (sandbox path and filesystem override)
- Confirm working on ThinkPad X1 Carbon Gen 13 (Lunar Lake-M, Realtek SoundWire 025D:1318)

### Backward compatibility
- HDA presets are unchanged — all new parameters have defaults that preserve existing behavior
- Existing `--windows` usage still works; the argument now also accepts extracted DriverStore paths