### PR TITLE
Fix HDA codec unpacking in autodetection error path

### DIFF
--- a/dolby_to_easyeffects.py
+++ b/dolby_to_easyeffects.py
@@ -833,7 +833,7 @@ def find_tuning_xml(windows_root: Path):
                 continue
 
     if not candidates:
-        hda_info = ", ".join(f"vendor={v} subsys={s}" for v, s in hda_codecs)
+        hda_info = ", ".join(f"vendor={v} subsys={s}" for v, s, _name in hda_codecs)
         sdw_info = ", ".join(f"man={m} part={p}" for m, p in sdw_devices)
         pci_info = f"pci_subsys={pci_subsys}" if pci_subsys else "no PCI subsystem"
         raise FileNotFoundError(


### PR DESCRIPTION
<img width="861" height="79" alt="image" src="https://github.com/user-attachments/assets/a95db683-858d-4db4-bc8b-f3e3edbb9d6e" />


  ## Summary

  `find_tuning_xml()` formatted the no-match diagnostic by unpacking `hda_codecs` as 2-tuples, but `get_hda_codec_ids()` returns 3-tuples of `(vendor_id, subsystem_id,
  codec_name)`. When autodetection failed, that mismatch raised `too many values to unpack` instead of emitting the intended error.

  ## Fix

  - Iterate as `for v, s, _name in hda_codecs` in the failure path.
  - Preserve the existing diagnostic behavior while avoiding the crash.

  ## Validation

  - `python3 -m pytest tests -q`
  - Reproduced the affected path locally and confirmed the converter now reaches the normal no-match diagnostic instead of crashing.

  ## Notes

  This is a narrow, low-risk fix in an error-reporting path. No output format or tuning logic changed.
