### PR TITLE
tools: fetch a Lenovo DAX3 tuning XML without Windows + A/B test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,10 @@ Versions are date-based (`vYYYY.MM`). Watch this repository on GitHub
   written by another version of this tool, as it already did for PipeWire
   confs — re-run the script on your tuning XML so they match the version
   you run.
+- Fetch a Lenovo laptop's DAX3 tuning XML without a Windows partition —
+  resolves the driver package from Lenovo's update catalog, verifies and
+  unpacks it.
+  ([#81](https://github.com/antoinecellerier/speaker-tuning-to-easyeffects/pull/81))
 - Mark additional tested devices: Framework Laptop 13 Pro (Intel Core Ultra
   Series 3)
   ([#73](https://github.com/antoinecellerier/speaker-tuning-to-easyeffects/issues/73)),

--- a/README.md
+++ b/README.md
@@ -429,9 +429,10 @@ python3 tools/fetch_driver/get_lenovo_dax_xml.py --dry-run   # show what it reso
 python3 tools/fetch_driver/get_lenovo_dax_xml.py             # fetch, verify, unpack
 ```
 
-It finishes by printing the converter command to run next, with the extracted
-directory already filled in — the path contains a `$`, so copy the line it
-gives you rather than retyping it.
+It unpacks into the repo's `driver-cache/`, which the converters' autoprobe
+already covers — so from the repo root the next step is just
+`python3 dolby_to_easyeffects.py`, no path to pass. The script prints the exact
+command to run, with `--windows` filled in on the rare occasions it's needed.
 
 <details>
 <summary>Manual extraction, or from a Lenovo driver EXE (no Windows partition)</summary>

--- a/README.md
+++ b/README.md
@@ -422,6 +422,14 @@ Those CPU/RAM figures are device-specific; reproduce them on your own hardware w
 
 The easiest way is to use `--windows` to auto-discover the XML from a mounted Windows partition. The script reads your audio codec's device and subsystem IDs from `/proc/asound` and matches them against the XMLs in the DriverStore.
 
+**No Windows partition, on a Lenovo laptop?** `tools/fetch_driver/get_lenovo_dax_xml.py` resolves the audio-driver package from Lenovo's update catalog for your machine type, downloads and checksum-verifies it, and extracts the DAX3 tuning XML (needs [`innoextract`](https://constexpr.org/innoextract/install)). It then prints the directory to pass to either converter:
+
+```bash
+python3 tools/fetch_driver/get_lenovo_dax_xml.py --dry-run   # show what it resolved
+python3 tools/fetch_driver/get_lenovo_dax_xml.py             # fetch, verify, unpack
+python3 dolby_to_easyeffects.py --windows ./driver-cache/extract/...   # then run a converter
+```
+
 <details>
 <summary>Manual extraction, or from a Lenovo driver EXE (no Windows partition)</summary>
 

--- a/README.md
+++ b/README.md
@@ -427,8 +427,11 @@ The easiest way is to use `--windows` to auto-discover the XML from a mounted Wi
 ```bash
 python3 tools/fetch_driver/get_lenovo_dax_xml.py --dry-run   # show what it resolved
 python3 tools/fetch_driver/get_lenovo_dax_xml.py             # fetch, verify, unpack
-python3 dolby_to_easyeffects.py --windows ./driver-cache/extract/...   # then run a converter
 ```
+
+It finishes by printing the converter command to run next, with the extracted
+directory already filled in — the path contains a `$`, so copy the line it
+gives you rather than retyping it.
 
 <details>
 <summary>Manual extraction, or from a Lenovo driver EXE (no Windows partition)</summary>

--- a/lib/dax/discover.py
+++ b/lib/dax/discover.py
@@ -210,6 +210,9 @@ def _detect_expected_subsys_ids() -> set[str]:
     return an empty set if no hardware is detected.
     """
     ids: set[str] = set()
+    # HDMI/DP codecs ride along here. Harmless — no Dolby tuning filename
+    # carries a display SSID — so this stays a superset rather than growing a
+    # filter the callers would have to agree on.
     for _vendor, subsys, _name in codecs.get_hda_codec_ids():
         ids.add(subsys.upper())
     pci_token = _pci_subsys_token(codecs.get_pci_audio_subsystem())
@@ -246,6 +249,19 @@ def _candidate_has_matching_xml(candidate: Path, expected_subsys: set[str]) -> b
         except OSError:
             continue
     return False
+
+
+def dirs_for_this_machine(dirs: list[Path]) -> list[Path]:
+    """Narrow candidate directories to those holding a tuning XML for this
+    machine.
+
+    Public so ``tools/fetch_driver`` picks the right directory out of a
+    per-SKU fan-out the same way the autoprobe picks between extracted trees
+    — one implementation, so the two can't drift. Returns ``[]`` when no
+    hardware is detected, which callers read as "can't narrow".
+    """
+    expected = _detect_expected_subsys_ids()
+    return [d for d in dirs if _candidate_has_matching_xml(d, expected)]
 
 
 def walk_for_dolby_xml_dirs(root: Path, max_depth: int = _CWD_PROBE_MAX_DEPTH) -> list[Path]:
@@ -403,8 +419,7 @@ def autoprobe_dolby_source() -> Path:
     # only one is for their device.
     hardware_matches: list[Path] = []
     if len(candidates) > 1:
-        expected = _detect_expected_subsys_ids()
-        hardware_matches = [c for c in candidates if _candidate_has_matching_xml(c, expected)]
+        hardware_matches = dirs_for_this_machine(candidates)
         if len(hardware_matches) == 1:
             _announce(hardware_matches[0])
             return hardware_matches[0]

--- a/lib/dax/discover.py
+++ b/lib/dax/discover.py
@@ -10,7 +10,11 @@ user input, walking `/proc/mounts` and then the working directory;
 `find_tuning_xml` answers the second, matching the `DEV_` / `MAN_` / `FUNC_` /
 `SUBSYS_` tokens in a filename against `lib/hardware/codecs.py`'s reading of
 the hardware, and falling back to each XML's own `<security-key>` when no
-filename matches. Everything else here is a helper to those two.
+filename matches. Everything else here is a helper to those two, bar
+the four names `tools/fetch_driver` reuses so it locates and chooses
+XMLs exactly as the converters do: `walk_for_dolby_xml_dirs`,
+`xmls_directly_under`, `dirs_for_this_machine` and
+`is_dolby_tuning_filename`.
 
 `autoprobe_all_dolby_xmls` is the union form of the first question — every
 XML the same probes can see — for the corpus tier and `tools/corpus_audit.py`.

--- a/lib/dax/discover.py
+++ b/lib/dax/discover.py
@@ -248,12 +248,15 @@ def _candidate_has_matching_xml(candidate: Path, expected_subsys: set[str]) -> b
     return False
 
 
-def _walk_for_dolby_xml_dirs(root: Path, max_depth: int = _CWD_PROBE_MAX_DEPTH) -> list[Path]:
+def walk_for_dolby_xml_dirs(root: Path, max_depth: int = _CWD_PROBE_MAX_DEPTH) -> list[Path]:
     """Return directories under ``root`` that directly contain a Dolby XML.
 
     Walks with ``followlinks=False`` and a depth cap (depth 0 = ``root``
     itself). Hidden subdirectories (``.git``, ``.venv``, etc.) are pruned
     in-place so they never enter the walk.
+
+    Public so ``tools/fetch_driver`` locates its freshly-extracted XMLs the
+    same way the autoprobe does, rather than re-deriving the name filter.
     """
     root_parts_len = len(root.parts)
     results: list[Path] = []
@@ -270,9 +273,12 @@ def _walk_for_dolby_xml_dirs(root: Path, max_depth: int = _CWD_PROBE_MAX_DEPTH) 
     return results
 
 
-def _xmls_directly_under(directory: Path) -> list[Path]:
+def xmls_directly_under(directory: Path) -> list[Path]:
     """DAX3-shaped XML files directly under ``directory`` — no recursion,
-    and the same name filter as every other probe here."""
+    and the same name filter as every other probe here.
+
+    Public for the same reason as ``walk_for_dolby_xml_dirs``.
+    """
     out: list[Path] = []
     try:
         for entry in sorted(directory.iterdir()):
@@ -321,13 +327,13 @@ def autoprobe_all_dolby_xmls() -> list[Path]:
         except OSError:
             wrappers = []
         for wrapper in wrappers:
-            for xml in _xmls_directly_under(wrapper):
+            for xml in xmls_directly_under(wrapper):
                 _add(xml)
-        for xml in _xmls_directly_under(driver_store):
+        for xml in xmls_directly_under(driver_store):
             _add(xml)
 
-    for directory in _walk_for_dolby_xml_dirs(Path.cwd()):
-        for xml in _xmls_directly_under(directory):
+    for directory in walk_for_dolby_xml_dirs(Path.cwd()):
+        for xml in xmls_directly_under(directory):
             _add(xml)
 
     return found
@@ -367,7 +373,7 @@ def autoprobe_dolby_source() -> Path:
     cwd = Path.cwd()
     if not mount_candidates:
         seen: set[Path] = set()
-        for cand in _walk_for_dolby_xml_dirs(cwd):
+        for cand in walk_for_dolby_xml_dirs(cwd):
             # Cosmetic lift: a directly-matched ``dax3_ext_*.inf_*`` wrapper
             # is reported as its parent (the extraction root), matching the
             # path the user would otherwise pass as ``--windows DIR``.

--- a/lib/packages.py
+++ b/lib/packages.py
@@ -62,6 +62,17 @@ _INSTALL = {
     NIXOS: "",
 }
 
+def install_verb(fam: str) -> str:
+    """The install-command prefix for `fam`, or "" when it has none.
+
+    "" covers NixOS (no imperative install verb — see `_nixos_command`) and an
+    unrecognised family. Exposed so a caller with its own out-of-tree package
+    (`tools/fetch_driver`'s `innoextract`) reuses the per-family verb instead
+    of copying this table and drifting from it.
+    """
+    return _INSTALL.get(fam, "")
+
+
 # The families whose install idiom really is "<prefix> <names>". NixOS is the
 # one that isn't, and every invariant below that assumes a pasteable command
 # is checked against this rather than `FAMILIES`.

--- a/lib/packages.py
+++ b/lib/packages.py
@@ -62,6 +62,7 @@ _INSTALL = {
     NIXOS: "",
 }
 
+
 def install_verb(fam: str) -> str:
     """The install-command prefix for `fam`, or "" when it has none.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1986,7 +1986,7 @@ def test_autoprobe_raises_when_no_candidates_anywhere(monkeypatch, tmp_path):
     """
     monkeypatch.setattr(discover, "_ntfs_family_mountpoints", lambda: [])
     monkeypatch.setattr(
-        discover, "_walk_for_dolby_xml_dirs", lambda _root: []
+        discover, "walk_for_dolby_xml_dirs", lambda _root: []
     )
     monkeypatch.chdir(tmp_path)
     with pytest.raises(

--- a/tests/test_fetch_driver.py
+++ b/tests/test_fetch_driver.py
@@ -4,9 +4,11 @@ No network: `_get` is monkeypatched to serve canned catalog / descriptor XML.
 """
 
 import hashlib
+import subprocess
 
 import pytest
 
+from lib.hardware import codecs
 from tools.fetch_driver import get_lenovo_dax_xml as g
 
 CATALOG = """<?xml version="1.0"?>
@@ -267,3 +269,78 @@ def test_an_exe_url_with_no_filename_is_rejected(monkeypatch, tmp_path):
         ["--exe-url", "https://x/", "--driver-cache", str(tmp_path)])
     with pytest.raises(g.Fail, match="no filename in"):
         g.run(args)
+
+
+def _fan_out(root, skus):
+    """A per-SKU extraction: one sibling directory per machine, as the Legion
+    Y540-15IRH installer lays it out."""
+    base = root / "code$GetExtractPath$" / "Dolby" / "ext_realtek_lenovo_ideapad"
+    made = {}
+    for subsys in skus:
+        d = base / f"sku_{subsys}"
+        d.mkdir(parents=True)
+        (d / f"DEV_0257_SUBSYS_{subsys}.xml").write_text("<x/>")
+        made[subsys] = d
+    return made
+
+
+def test_a_per_sku_fan_out_resolves_to_this_machine(tmp_path, monkeypatch):
+    """A fan-out used to abort after the whole driver had been downloaded.
+    Picking dirs[0] would have picked another laptop's tuning."""
+    dirs = _fan_out(tmp_path, ["17AA380F", "17AA5094", "17AA22E6"])
+    monkeypatch.setattr(
+        codecs, "get_hda_codec_ids", lambda: [("10EC0257", "17AA380F", "ALC257")])
+    monkeypatch.setattr(codecs, "get_pci_audio_subsystem", lambda: None)
+    assert g.tuning_xml_dir(tmp_path) == dirs["17AA380F"]
+
+
+def test_a_fan_out_that_matches_nothing_still_names_every_directory(tmp_path,
+                                                                    monkeypatch):
+    """Narrowing that finds nothing must not silently pick one."""
+    _fan_out(tmp_path, ["17AA380F", "17AA5094"])
+    monkeypatch.setattr(
+        codecs, "get_hda_codec_ids", lambda: [("10EC0257", "17AA9999", "ALC257")])
+    monkeypatch.setattr(codecs, "get_pci_audio_subsystem", lambda: None)
+    with pytest.raises(g.Fail, match="more than one directory") as excinfo:
+        g.tuning_xml_dir(tmp_path)
+    assert "sku_17AA380F" in str(excinfo.value)
+    assert "sku_17AA5094" in str(excinfo.value)
+
+
+def test_an_extraction_of_only_companions_retries_unfiltered(tmp_path,
+                                                             monkeypatch):
+    """`_settings`/`_dmic` companions are not tuning XMLs. Judging the filtered
+    pass by "any .xml" called it a success and skipped the retry that would
+    have found the real files."""
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        out = tmp_path / "cache" / "extract"
+        out.mkdir(parents=True, exist_ok=True)
+        if "-I" in cmd:                      # filtered pass: companions only
+            (out / "DEV_0257_SUBSYS_17AA5094_dmic.xml").write_text("<x/>")
+        else:                                # unfiltered retry: the real thing
+            (out / "DEV_0257_SUBSYS_17AA5094.xml").write_text("<x/>")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(g.shutil, "which", lambda _: "/usr/bin/innoextract")
+    monkeypatch.setattr(g.subprocess, "run", fake_run)
+    out = g.extract(tmp_path / "d.exe", tmp_path / "cache")
+    assert len(calls) == 2, "the unfiltered retry never ran"
+    assert g.tuning_xml_dir(out).name == "extract"
+
+
+def test_a_subsystem_two_sku_dirs_share_stays_ambiguous(tmp_path, monkeypatch):
+    """Real packages reuse a subsystem across SKU directories (17AA382B sits in
+    two of the Legion Y540 package's fifteen). Narrowing must not guess."""
+    _fan_out(tmp_path, ["17AA382B", "17AA3833"])
+    extra = tmp_path / "code$GetExtractPath$" / "Dolby" / \
+        "ext_realtek_lenovo_ideapad" / "sku_other"
+    extra.mkdir(parents=True)
+    (extra / "DEV_0257_SUBSYS_17AA382B.xml").write_text("<x/>")
+    monkeypatch.setattr(
+        codecs, "get_hda_codec_ids", lambda: [("10EC0257", "17AA382B", "ALC257")])
+    monkeypatch.setattr(codecs, "get_pci_audio_subsystem", lambda: None)
+    with pytest.raises(g.Fail, match="more than one directory"):
+        g.tuning_xml_dir(tmp_path)

--- a/tests/test_fetch_driver.py
+++ b/tests/test_fetch_driver.py
@@ -1,0 +1,211 @@
+"""Catalog resolution and safety checks for tools/fetch_driver/get_lenovo_dax_xml.py.
+
+No network: `_get` is monkeypatched to serve canned catalog / descriptor XML.
+"""
+
+import hashlib
+
+import pytest
+
+from tools.fetch_driver import get_lenovo_dax_xml as g
+
+CATALOG = """<?xml version="1.0"?>
+<packages count="3">
+  <package><location>https://x/dock.xml</location><category>Audio</category></package>
+  <package><location>https://x/realtek.xml</location><category>Audio</category></package>
+  <package><location>https://x/net.xml</location><category>Networking</category></package>
+</packages>"""
+
+DOCK = """<?xml version="1.0"?>
+<Package name="DOCK_AUDIO_N20PE" version="6.3.9600.2299">
+  <Files><File><Name>n20pe10w.exe</Name><CRC>aa</CRC></File></Files>
+</Package>"""
+
+REALTEK = """<?xml version="1.0"?>
+<Package name="AUD_R1MAR" version="6.0.9366.1">
+  <PackageXML>
+    <HardwareID><![CDATA[SWC\\VEN_DOLBY&PID_DAX3APOSVC]]></HardwareID>
+    <HardwareID><![CDATA[HDAUDIO\\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5094]]></HardwareID>
+  </PackageXML>
+  <Files>
+    <File><Name>r1mra06w.exe</Name><CRC>BEEF</CRC></File>
+    <File id="EN"><Name>r1mra06w.html</Name><CRC>99</CRC></File>
+  </Files>
+</Package>"""
+
+OLDER_REALTEK = REALTEK.replace('version="6.0.9366.1"', 'version="6.0.9000.1"')
+
+# An audio driver that serves the codec but carries no Dolby APO hwid — the
+# common case (5 of 8 machine types in the PR review's sweep).
+PLAIN_AUDIO = """<?xml version="1.0"?>
+<Package name="AUD_N3AA1" version="6.0.9764.1">
+  <PackageXML>
+    <HardwareID><![CDATA[HDAUDIO\\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5094]]></HardwareID>
+  </PackageXML>
+  <Files><File><Name>n3aa1.exe</Name><CRC>ab</CRC></File></Files>
+</Package>"""
+
+# The Dolby *Vision* Provisioning Kit — a display package that used to leak
+# into the audio candidate pool via a name-substring match.
+DOLBY_VISION = """<?xml version="1.0"?>
+<Package name="LenovoProvisionDolbyVision" version="2.0.1.0">
+  <Files><File><Name>dolbyvision.exe</Name><CRC>cd</CRC></File></Files>
+</Package>"""
+
+TOKENS = [("10EC", "0257", "17AA5094", "ALC257")]
+
+
+@pytest.fixture
+def net(monkeypatch):
+    pages = {
+        "https://download.lenovo.com/catalog/20XL_Win11.xml": CATALOG,
+        "https://x/dock.xml": DOCK,
+        "https://x/realtek.xml": REALTEK,
+        "https://x/net.xml": "<Package name='NET'/>",
+    }
+
+    def fake_get(url):
+        if url not in pages:
+            raise g.Fail(f"{url} -> HTTP 404")
+        return pages[url].encode()
+
+    monkeypatch.setattr(g, "_get", fake_get)
+    return pages
+
+
+def test_catalog_filters_to_audio(net):
+    urls = g.catalog_packages("20XL", ["11"])
+    assert urls == ["https://x/dock.xml", "https://x/realtek.xml"]
+
+
+def test_pick_prefers_dolby_apo_and_skips_dock(net):
+    d = g.pick_descriptor(["https://x/dock.xml", "https://x/realtek.xml"], [])
+    assert d.name == "AUD_R1MAR"
+    assert d.exe_name == "r1mra06w.exe"
+    assert d.exe_url == "https://x/r1mra06w.exe"
+    assert d.sha256 == "beef"
+
+
+def test_pick_breaks_ties_on_version(net, monkeypatch):
+    monkeypatch.setattr(g, "_get", lambda u: {
+        "https://x/a.xml": REALTEK, "https://x/b.xml": OLDER_REALTEK,
+    }[u].encode())
+    d = g.pick_descriptor(["https://x/b.xml", "https://x/a.xml"], [])
+    assert d.version == "6.0.9366.1"
+
+
+def test_pick_without_dolby_uses_highest_version(monkeypatch):
+    plain = DOCK.replace("DOCK_AUDIO_N20PE", "AUDIO_PLAIN")
+    older = plain.replace('version="6.3.9600.2299"', 'version="6.1.0.0"')
+    monkeypatch.setattr(g, "_get", lambda u: {
+        "https://x/new.xml": plain, "https://x/old.xml": older,
+    }[u].encode())
+    d = g.pick_descriptor(["https://x/old.xml", "https://x/new.xml"], [])
+    assert d.name == "AUDIO_PLAIN"
+    assert d.version == "6.3.9600.2299"
+
+
+def test_pick_prefers_descriptor_that_serves_the_codec(monkeypatch):
+    # PLAIN_AUDIO serves the codec but has no Dolby APO; a higher-version
+    # package that serves nothing must not win on version alone.
+    other = REALTEK.replace("AUD_R1MAR", "AUD_OTHER").replace(
+        "6.0.9366.1", "9.9.9.9").replace(
+        "HDAUDIO\\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5094",
+        "HDAUDIO\\FUNC_01&VEN_10EC&DEV_0999")
+    monkeypatch.setattr(g, "_get", lambda u: {
+        "https://x/plain.xml": PLAIN_AUDIO, "https://x/other.xml": other,
+    }[u].encode())
+    d = g.pick_descriptor(["https://x/other.xml", "https://x/plain.xml"], TOKENS)
+    assert d.name == "AUD_N3AA1"
+
+
+def test_pick_ignores_dolby_vision_display_package(monkeypatch):
+    monkeypatch.setattr(g, "_get", lambda u: {
+        "https://x/vision.xml": DOLBY_VISION, "https://x/audio.xml": PLAIN_AUDIO,
+    }[u].encode())
+    d = g.pick_descriptor(["https://x/vision.xml", "https://x/audio.xml"], TOKENS)
+    assert d.name == "AUD_N3AA1"
+
+
+def test_catalog_unreachable_is_actionable(monkeypatch):
+    monkeypatch.setattr(g, "_get", lambda u: (_ for _ in ()).throw(g.Fail("HTTP 403")))
+    with pytest.raises(g.Fail, match="no catalog reachable"):
+        g.catalog_packages("ZZZZ", ["11", "10"])
+
+
+def test_download_aborts_on_checksum_mismatch(tmp_path, monkeypatch):
+    payload = b"not the real driver"
+
+    class FakeResp:
+        headers = {"Content-Length": str(len(payload))}
+
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self, n=-1):
+            b, self._done = getattr(self, "_buf", payload), True
+            if getattr(self, "_sent", False):
+                return b""
+            self._sent = True
+            return b
+
+    monkeypatch.setattr(g.urllib.request, "urlopen", lambda *a, **k: FakeResp())
+    dest = tmp_path / "d.exe"
+    with pytest.raises(g.Fail, match="checksum mismatch"):
+        g.download("https://x/d.exe", dest, "0" * 64)
+    assert not dest.exists()
+
+
+def test_download_accepts_matching_checksum(tmp_path, monkeypatch):
+    payload = b"good"
+    good = hashlib.sha256(payload).hexdigest()
+
+    class FakeResp:
+        headers = {}
+
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self, n=-1):
+            if getattr(self, "_sent", False):
+                return b""
+            self._sent = True
+            return payload
+
+    monkeypatch.setattr(g.urllib.request, "urlopen", lambda *a, **k: FakeResp())
+    dest = tmp_path / "d.exe"
+    g.download("https://x/d.exe", dest, good)
+    assert dest.read_bytes() == payload
+
+
+@pytest.mark.parametrize("field,value,expect", [
+    ("product_sku", "LENOVO_MT_20XL_BU_Think_FM_ThinkPad T14 Gen 2a", "20XL"),
+    ("product_name", "20XLS23200", "20XL"),
+])
+def test_machine_type_parsing(monkeypatch, field, value, expect):
+    vals = {"sys_vendor": "LENOVO", "product_sku": "", "product_name": "", field: value}
+    monkeypatch.setattr(g, "_dmi", lambda f: vals.get(f, ""))
+    assert g.machine_type() == expect
+
+
+def test_machine_type_empty_when_not_lenovo(monkeypatch):
+    monkeypatch.setattr(g, "_dmi", lambda f: "Dell Inc." if f == "sys_vendor" else "x")
+    assert g.machine_type() == ""
+
+
+def test_extract_without_innoextract_names_the_package(tmp_path, monkeypatch):
+    monkeypatch.setattr(g.shutil, "which", lambda _: None)
+    monkeypatch.setattr(g.packages, "family", lambda: g.packages.DEBIAN)
+    with pytest.raises(g.Fail, match="innoextract"):
+        g.extract(tmp_path / "x.exe", tmp_path)
+
+
+def test_tuning_xml_dir_finds_the_one_dolby_dir(tmp_path):
+    deep = tmp_path / "code$GetExtractPath$" / "Dolby" / "03_dax_ext"
+    deep.mkdir(parents=True)
+    (deep / "DEV_0257_SUBSYS_17AA5094.xml").write_text("<x/>")
+    (deep / "DEV_0257_SUBSYS_17AA5094_dmic.xml").write_text("<x/>")  # companion
+    assert g.tuning_xml_dir(tmp_path) == deep
+
+
+def test_tuning_xml_dir_errors_when_nothing_extracted(tmp_path):
+    with pytest.raises(g.Fail, match="no Dolby DAX3 tuning"):
+        g.tuning_xml_dir(tmp_path)

--- a/tests/test_fetch_driver.py
+++ b/tests/test_fetch_driver.py
@@ -395,3 +395,66 @@ def test_a_missing_innoextract_names_the_command_for_this_distro(
     monkeypatch.setattr(g.packages, "family", lambda *a, **k: fam)
     with pytest.raises(g.Fail, match=re.escape(expect)):
         g.extract(tmp_path / "d.exe", tmp_path / "cache")
+
+
+def _extracted(root, subsys="17AA22E6", where="driver-cache/extract"):
+    d = root.joinpath(*where.split("/")) / "code$GetExtractPath$" / "Dolby" / "03_dax_ext"
+    d.mkdir(parents=True)
+    (d / f"DEV_0287_SUBSYS_{subsys}.xml").write_text("<x/>")
+    return d
+
+
+def test_next_steps_drop_the_path_when_a_bare_run_would_find_it(
+        tmp_path, monkeypatch, capsys):
+    """The extracted path contains a `$`, so an unquoted paste breaks. When the
+    converters would autodiscover it, the shortest correct command has no path
+    in it at all."""
+    d = _extracted(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    g._print_next_steps(d)
+    out = capsys.readouterr().out
+    assert "python3 dolby_to_easyeffects.py\n" in out
+    assert "--windows" not in out
+
+
+def test_next_steps_name_the_directory_when_a_bare_run_would_not(
+        tmp_path, monkeypatch, capsys):
+    """Extracted somewhere the cwd walk can't reach, the explicit --windows
+    form is the only one that works -- and it has to be quoted."""
+    d = _extracted(tmp_path / "elsewhere")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    g._print_next_steps(d)
+    out = capsys.readouterr().out
+    assert "--windows" in out
+    assert "'" in out, "the $ in the path must be quoted"
+
+
+def test_next_steps_stay_explicit_when_two_trees_are_in_reach(
+        tmp_path, monkeypatch, capsys):
+    """A second extracted tree makes a bare run ambiguous unless exactly one
+    matches this machine, so don't promise autodiscovery."""
+    mine = _extracted(tmp_path, "17AA22E6", "a")
+    _extracted(tmp_path, "17AA5094", "b")
+    monkeypatch.setattr(codecs, "get_hda_codec_ids", lambda: [])
+    monkeypatch.setattr(codecs, "get_pci_audio_subsystem", lambda: None)
+    monkeypatch.chdir(tmp_path)
+    g._print_next_steps(mine)
+    assert "--windows" in capsys.readouterr().out
+
+
+def test_a_second_tree_this_machine_does_not_match_still_autodiscovers(
+        tmp_path, monkeypatch, capsys):
+    """Two trees but only one for this laptop: the autoprobe narrows to it, so
+    a bare run is unambiguous and the path is still noise."""
+    mine = _extracted(tmp_path, "17AA22E6", "a")
+    _extracted(tmp_path, "17AA5094", "b")
+    monkeypatch.setattr(
+        codecs, "get_hda_codec_ids", lambda: [("10EC0287", "17AA22E6", "ALC287")])
+    monkeypatch.setattr(codecs, "get_pci_audio_subsystem", lambda: None)
+    monkeypatch.chdir(tmp_path)
+    g._print_next_steps(mine)
+    out = capsys.readouterr().out
+    assert "--windows" not in out
+    assert "python3 dolby_to_easyeffects.py\n" in out

--- a/tests/test_fetch_driver.py
+++ b/tests/test_fetch_driver.py
@@ -28,7 +28,7 @@ REALTEK = """<?xml version="1.0"?>
     <HardwareID><![CDATA[HDAUDIO\\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5094]]></HardwareID>
   </PackageXML>
   <Files>
-    <File><Name>r1mra06w.exe</Name><CRC>BEEF</CRC></File>
+    <File><Name>r1mra06w.exe</Name><CRC>BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB</CRC></File>
     <File id="EN"><Name>r1mra06w.html</Name><CRC>99</CRC></File>
   </Files>
 </Package>"""
@@ -83,7 +83,7 @@ def test_pick_prefers_dolby_apo_and_skips_dock(net):
     assert d.name == "AUD_R1MAR"
     assert d.exe_name == "r1mra06w.exe"
     assert d.exe_url == "https://x/r1mra06w.exe"
-    assert d.sha256 == "beef"
+    assert d.sha256 == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
 
 def test_pick_breaks_ties_on_version(net, monkeypatch):
@@ -209,3 +209,61 @@ def test_tuning_xml_dir_finds_the_one_dolby_dir(tmp_path):
 def test_tuning_xml_dir_errors_when_nothing_extracted(tmp_path):
     with pytest.raises(g.Fail, match="no Dolby DAX3 tuning"):
         g.tuning_xml_dir(tmp_path)
+
+
+def test_a_network_error_mid_download_is_a_message_not_a_traceback(tmp_path,
+                                                                   monkeypatch):
+    """A dropped connection used to escape `main`'s `except Fail` as a
+    traceback, which reads as a bug in the tool rather than a bad network."""
+    def boom(*a, **k):
+        raise g.urllib.error.URLError("connection reset")
+
+    monkeypatch.setattr(g.urllib.request, "urlopen", boom)
+    dest = tmp_path / "d.exe"
+    with pytest.raises(g.Fail, match="connection reset"):
+        g.download("https://x/d.exe", dest, "0" * 64)
+    assert not dest.exists()
+
+
+def test_an_http_error_on_the_exe_is_a_message_not_a_traceback(tmp_path,
+                                                               monkeypatch):
+    def boom(*a, **k):
+        raise g.urllib.error.HTTPError("https://x/d.exe", 404, "Not Found",
+                                       None, None)
+
+    monkeypatch.setattr(g.urllib.request, "urlopen", boom)
+    with pytest.raises(g.Fail, match="HTTP 404"):
+        g.download("https://x/d.exe", tmp_path / "d.exe", "0" * 64)
+
+
+def test_unreadable_descriptors_are_named_not_hidden(monkeypatch):
+    """All-403 descriptors used to report "none look like an internal-codec
+    driver" — true of an empty list, and the wrong thing to go fix."""
+    monkeypatch.setattr(
+        g, "_get", lambda u: (_ for _ in ()).throw(g.Fail(f"{u} -> HTTP 403")))
+    with pytest.raises(g.Fail, match=r"HTTP 403") as excinfo:
+        g.pick_descriptor(["https://x/a.xml", "https://x/b.xml"], TOKENS)
+    assert "https://x/a.xml" in str(excinfo.value)
+    assert "https://x/b.xml" in str(excinfo.value)
+
+
+def test_a_catalog_with_no_audio_package_says_so(monkeypatch):
+    monkeypatch.setattr(g, "_get", lambda u: b"")
+    with pytest.raises(g.Fail, match="lists no audio package"):
+        g.pick_descriptor([], TOKENS)
+
+
+def test_a_crc_that_is_not_a_sha256_skips_verification():
+    """`<CRC>` is a SHA-256 on every descriptor we've read, but the tag name
+    doesn't promise one. Treating a CRC32 as a digest would abort every run of
+    that machine type after the full download, blaming the file."""
+    assert g.Descriptor("https://x/d.xml", DOCK.encode()).sha256 == ""
+    assert g.Descriptor("https://x/r.xml", REALTEK.encode()).sha256 == "b" * 64
+
+
+def test_an_exe_url_with_no_filename_is_rejected(monkeypatch, tmp_path):
+    monkeypatch.setattr(g, "codec_tokens", lambda: [])
+    args = g.build_parser().parse_args(
+        ["--exe-url", "https://x/", "--driver-cache", str(tmp_path)])
+    with pytest.raises(g.Fail, match="no filename in"):
+        g.run(args)

--- a/tests/test_fetch_driver.py
+++ b/tests/test_fetch_driver.py
@@ -181,6 +181,12 @@ def test_download_accepts_matching_checksum(tmp_path, monkeypatch):
 @pytest.mark.parametrize("field,value,expect", [
     ("product_sku", "LENOVO_MT_20XL_BU_Think_FM_ThinkPad T14 Gen 2a", "20XL"),
     ("product_name", "20XLS23200", "20XL"),
+    # A marketing name is not a machine type. Slicing four characters off
+    # these yielded THIN / IDEA, which 404 the catalog with a message that
+    # blames the machine type the user never gave.
+    ("product_name", "ThinkPad X1 Carbon Gen 9", ""),
+    ("product_name", "IdeaPad Pro 5 14AHP9", ""),
+    ("product_name", "Legion Y540-15IRH", ""),
 ])
 def test_machine_type_parsing(monkeypatch, field, value, expect):
     vals = {"sys_vendor": "LENOVO", "product_sku": "", "product_name": "", field: value}
@@ -344,3 +350,17 @@ def test_a_subsystem_two_sku_dirs_share_stays_ambiguous(tmp_path, monkeypatch):
     monkeypatch.setattr(codecs, "get_pci_audio_subsystem", lambda: None)
     with pytest.raises(g.Fail, match="more than one directory"):
         g.tuning_xml_dir(tmp_path)
+
+
+def test_hdmi_codecs_are_not_offered_to_the_catalog():
+    """A display codec has no Dolby tuning, and its DEV token must not join the
+    codec match. The old SSID test caught AMD's 00AA0100 but not Intel's."""
+    ids = [("10EC0287", "17AA22E6", "Realtek ALC287"),
+           ("8086281C", "80860101", "Intel Alderlake-P HDMI"),
+           ("1002AA01", "00AA0100", "ATI R6xx HDMI")]
+    real = codecs.get_hda_codec_ids
+    codecs.get_hda_codec_ids = lambda: ids
+    try:
+        assert g.codec_tokens() == [("10EC", "0287", "17AA22E6", "Realtek ALC287")]
+    finally:
+        codecs.get_hda_codec_ids = real

--- a/tests/test_fetch_driver.py
+++ b/tests/test_fetch_driver.py
@@ -4,6 +4,7 @@ No network: `_get` is monkeypatched to serve canned catalog / descriptor XML.
 """
 
 import hashlib
+import re
 import subprocess
 
 import pytest
@@ -379,3 +380,18 @@ def test_hdmi_codecs_are_not_offered_to_the_catalog():
         assert g.codec_tokens() == [("10EC", "0287", "17AA22E6", "Realtek ALC287")]
     finally:
         codecs.get_hda_codec_ids = real
+
+
+@pytest.mark.parametrize("fam,expect", [
+    ("debian", "sudo apt install innoextract"),
+    ("gentoo", "emerge app-arch/innoextract"),
+    # innoextract is exec'd by this process, so a nix-shell does reach it --
+    # the generic "install it from your distribution" was the wrong answer.
+    ("nixos", "nix-shell -p innoextract"),
+])
+def test_a_missing_innoextract_names_the_command_for_this_distro(
+        tmp_path, monkeypatch, fam, expect):
+    monkeypatch.setattr(g.shutil, "which", lambda _: None)
+    monkeypatch.setattr(g.packages, "family", lambda *a, **k: fam)
+    with pytest.raises(g.Fail, match=re.escape(expect)):
+        g.extract(tmp_path / "d.exe", tmp_path / "cache")

--- a/tests/test_fetch_driver.py
+++ b/tests/test_fetch_driver.py
@@ -12,10 +12,11 @@ from lib.hardware import codecs
 from tools.fetch_driver import get_lenovo_dax_xml as g
 
 CATALOG = """<?xml version="1.0"?>
-<packages count="3">
+<packages count="4">
   <package><location>https://x/dock.xml</location><category>Audio</category></package>
   <package><location>https://x/realtek.xml</location><category>Audio</category></package>
   <package><location>https://x/net.xml</location><category>Networking</category></package>
+  <package><location>https://x/lenovoprovisiondolbyvisionp17_2_.xml</location><category>Video</category></package>
 </packages>"""
 
 DOCK = """<?xml version="1.0"?>
@@ -50,7 +51,7 @@ PLAIN_AUDIO = """<?xml version="1.0"?>
 # The Dolby *Vision* Provisioning Kit — a display package that used to leak
 # into the audio candidate pool via a name-substring match.
 DOLBY_VISION = """<?xml version="1.0"?>
-<Package name="LenovoProvisionDolbyVision" version="2.0.1.0">
+<Package name="LenovoProvisionDolbyVision" version="99.0.1.0">
   <Files><File><Name>dolbyvision.exe</Name><CRC>cd</CRC></File></Files>
 </Package>"""
 
@@ -78,6 +79,20 @@ def net(monkeypatch):
 def test_catalog_filters_to_audio(net):
     urls = g.catalog_packages("20XL", ["11"])
     assert urls == ["https://x/dock.xml", "https://x/realtek.xml"]
+
+
+def test_pick_skips_a_dock_audio_package(net, monkeypatch):
+    """DOCK_ is USB dock audio, not the internal codec. It carries no Dolby
+    hwid either, so give it one — otherwise this passes on the wrong reason."""
+    monkeypatch.setattr(g, "_get", lambda u: {
+        "https://x/dock.xml": DOCK.replace(
+            "<Files>",
+            "<PackageXML><HardwareID><![CDATA[SWC\\VEN_DOLBY&PID_DAX3APOSVC]]>"
+            "</HardwareID></PackageXML><Files>"),
+        "https://x/plain.xml": PLAIN_AUDIO,
+    }[u].encode())
+    d = g.pick_descriptor(["https://x/dock.xml", "https://x/plain.xml"], [])
+    assert d.name == "AUD_N3AA1"
 
 
 def test_pick_prefers_dolby_apo_and_skips_dock(net):
@@ -202,7 +217,7 @@ def test_machine_type_empty_when_not_lenovo(monkeypatch):
 def test_extract_without_innoextract_names_the_package(tmp_path, monkeypatch):
     monkeypatch.setattr(g.shutil, "which", lambda _: None)
     monkeypatch.setattr(g.packages, "family", lambda: g.packages.DEBIAN)
-    with pytest.raises(g.Fail, match="innoextract"):
+    with pytest.raises(g.Fail, match=r"sudo apt install innoextract"):
         g.extract(tmp_path / "x.exe", tmp_path)
 
 

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -433,3 +433,25 @@ def test_print_install_hint_falls_back_to_every_family(monkeypatch):
     # distributions they are not on, and this prints on an error screen where
     # every extra line pushes the next step further down.
     assert [t for s, t in lines if s == "dim"] == []
+
+
+@pytest.mark.parametrize("fam", packages.FAMILIES)
+def test_install_verb_answers_exactly_the_families_with_a_command(fam):
+    """`install_verb` is the reusable half of `install_command`, for a caller
+    whose package this file doesn't carry (`tools/fetch_driver`'s innoextract).
+    A verb that went missing would leave that caller printing a bare package
+    name as if it were a command."""
+    verb = packages.install_verb(fam)
+    assert bool(verb) == (fam in packages.COMMAND_FAMILIES)
+    if verb:
+        assert packages.install_command([packages.LSP_LV2], fam).startswith(
+            verb + " ")
+
+
+def test_install_verb_spells_out_the_package_manager():
+    assert packages.install_verb(packages.DEBIAN) == "sudo apt install"
+    assert packages.install_verb(packages.ARCH) == "sudo pacman -S"
+    # NixOS has no imperative install verb, and an unknown family has none
+    # either -- both must read as "no command", not as a broken prefix.
+    assert packages.install_verb(packages.NIXOS) == ""
+    assert packages.install_verb("nonesuch") == ""

--- a/tools/README.md
+++ b/tools/README.md
@@ -5,8 +5,9 @@ conversion. Each script exists to keep something *else* right: a generated
 data table in `lib/data/`, a figure in `docs/`, the release notes, the copy a
 run prints, or the converter's own output. They are listed below with what
 they keep correct and who runs them, because that — not the filename — is how
-you find the one you need. (The two exceptions — `ab_sink.sh` and
-`fetch_driver/` — get their own sections below.)
+you find the one you need. (`ab_sink.sh` is a listening aid rather than a
+correctness check; `fetch_driver/` is the one thing here an end user runs,
+and gets its own section below.)
 
 One near-exception to "nothing here is part of the conversion":
 [`measure_pw/validate_conf.py`](measure_pw/validate_conf.py) runs the same
@@ -55,7 +56,7 @@ only which question the directory answers.
 ## fetch_driver/ — a staging area, not a new category
 
 [`fetch_driver/get_lenovo_dax_xml.py`](fetch_driver/get_lenovo_dax_xml.py) is
-the one thing here an end user runs directly: on a Lenovo laptop with no
+the script that end user runs: on a Lenovo laptop with no
 Windows partition it resolves the audio-driver package from Lenovo's update
 catalog, verifies and unpacks it, and prints the extracted-XML directory to
 hand to a converter. It does **not** run a converter — that step is meant to

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,11 +1,12 @@
 # tools/ — the scripts that keep everything else correct
 
-Nothing in here ships to a user, and nothing here is part of the conversion.
-Each script exists to keep something *else* right: a generated data table in
-`lib/data/`, a figure in `docs/`, the release notes, the copy a run prints, or
-the converter's own output. They are listed below with what they keep correct
-and who runs them, because that — not the filename — is how you find the one
-you need.
+Almost nothing in here ships to a user, and nothing here is part of the
+conversion. Each script exists to keep something *else* right: a generated
+data table in `lib/data/`, a figure in `docs/`, the release notes, the copy a
+run prints, or the converter's own output. They are listed below with what
+they keep correct and who runs them, because that — not the filename — is how
+you find the one you need. (The two exceptions — `ab_sink.sh` and
+`fetch_driver/` — get their own sections below.)
 
 One near-exception to "nothing here is part of the conversion":
 [`measure_pw/validate_conf.py`](measure_pw/validate_conf.py) runs the same
@@ -27,6 +28,7 @@ audio and no PipeWire daemon.)
 | script | what it keeps correct | who runs it, and when |
 |---|---|---|
 | [`_wavio.py`](_wavio.py) | Every WAV read in the measurement tree. `pw-record` writes a `PEAK` chunk that `scipy.io.wavfile` doesn't recognise and warns about on each read; this strips it | Nobody directly — it has no CLI. Nine scripts across `measure_dax/`, `measure_ee/` and `measure_pw/` `sys.path`-insert this directory and `from _wavio import read`. See below for why it lives here |
+| [`ab_sink.sh`](ab_sink.sh) | Nothing — a listening aid. Flips the default sink between the generated Dolby voicing sinks and the raw speaker with `wpctl`, moving playing streams over immediately, so `--variant all --target-sink ''` can be A/B'd by ear | You, while choosing a voicing. Independent of the converters — lists whatever `Audio/Sink` nodes exist |
 | [`changelog_section.py`](changelog_section.py) | The GitHub Release — slices `CHANGELOG.md` down to one version's section for the notes, and (`--title`) lifts the heading's tagline into the release title | `.github/workflows/release.yml`, on a pushed `vYYYY.MM` tag. Exits non-zero on a missing section, or on a heading still carrying a date instead of a tagline, so the job fails loudly instead of publishing empty or misnamed notes. Guarded by `tests/test_changelog_section.py`, which also holds every `## v` heading in the real file to the shape — CI runs no tests on a tag push |
 | [`check_move_purity.py`](check_move_purity.py) | `git blame -C -C` history across an extraction: it proves a commit is *pure code motion* — every line it adds under `lib/` was already there, byte-for-byte, in a line it removed | You, by hand, against one commit, before pushing an extraction. Wired to nothing; the rule it enforces is in `docs/code-organisation.md`, "Splitting the single-file scripts" |
 | [`corpus_audit.py`](corpus_audit.py) | Every cross-device figure in `docs/cross-device-findings.md` and `docs/design-notes.md`. Those numbers are meant to be re-derived from this, never carried forward | You, after pulling new driver packages; and the **/copy-audit** skill, which captures its output as the evidence reviewers check numbers against. Also imported as a library — see below. Guarded by `tests/test_corpus_audit.py` |
@@ -49,6 +51,18 @@ only which question the directory answers.
 | [`measure_ee/`](measure_ee/) | Whether the generated preset, running live in EasyEffects, matches that ground truth — plus the variant sweeps that narrow a candidate change before it is adopted | You, through **/audio-validate**. EE-side captures go stale after any FIR or scaling change; regenerate before comparing |
 | [`measure_perf/`](measure_perf/) | The README's "which should I use?" guidance: CPU cycles and memory for the same preset through EasyEffects vs the PipeWire filter-chain | You, when that cost claim needs re-measuring on a device |
 | [`measure_pw/`](measure_pw/) | That the PipeWire `filter-chain` conf is equivalent to the EasyEffects chain in both frequency and time domain — and, through `validate_conf.py`, that it is schema-valid at all | The comparisons: you, through the handoff. `validate_conf.py`: you, against a conf already on disk — `ee_to_pipewire.py` runs the same check in process on every run |
+
+## fetch_driver/ — a staging area, not a new category
+
+[`fetch_driver/get_lenovo_dax_xml.py`](fetch_driver/get_lenovo_dax_xml.py) is
+the one thing here an end user runs directly: on a Lenovo laptop with no
+Windows partition it resolves the audio-driver package from Lenovo's update
+catalog, verifies and unpacks it, and prints the extracted-XML directory to
+hand to a converter. It does **not** run a converter — that step is meant to
+move inside `dolby_to_easyeffects.py` (a "no XML found, fetch it?" prompt),
+and this directory is where that capability is being staged until it lands,
+not a permanent "user-facing tools" bucket. Full usage:
+[`fetch_driver/README.md`](fetch_driver/README.md).
 
 ## Three files that look misplaced
 

--- a/tools/ab_sink.sh
+++ b/tools/ab_sink.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# A/B the Dolby voicings against the raw speaker, by ear.
+#
+# Run `dolby_to_pipewire.py --variant all --target-sink ''` and you have one
+# sink per voicing alongside your untouched speaker sink. This flips the
+# default sink between them with wpctl, which moves already-playing streams
+# over immediately -- loop a track and cycle sinks under it. Independent of
+# the converters: it lists whatever Audio/Sink nodes exist, Dolby ones first.
+#
+#   tools/ab_sink.sh          # show the menu + current default
+#   tools/ab_sink.sh next     # cycle to the next option
+#   tools/ab_sink.sh raw      # jump to the raw (unprocessed) speaker
+#   tools/ab_sink.sh 2        # pick menu entry 2
+set -uo pipefail
+
+command -v wpctl  >/dev/null || { echo "wpctl not found (install wireplumber)" >&2; exit 1; }
+command -v pw-dump >/dev/null || { echo "pw-dump not found" >&2; exit 1; }
+
+# Menu order: Dolby variants first (sorted), then everything else. One entry per
+# line as "<id>\t<label>".
+mapfile -t SINKS < <(
+  pw-dump | python3 -c '
+import json, sys
+sinks = [n for n in json.load(sys.stdin)
+         if n.get("info", {}).get("props", {}).get("media.class") == "Audio/Sink"]
+def label(n):
+    p = n["info"]["props"]
+    return p.get("node.description") or p.get("node.name") or "?"
+for n in sorted(sinks, key=lambda n: (0 if "Dolby" in label(n) else 1, label(n))):
+    print(str(n["id"]) + "\t" + label(n))
+'
+)
+(( ${#SINKS[@]} )) || { echo "no audio sinks found" >&2; exit 1; }
+
+# Numeric id of the current default sink, or empty.
+current() {
+  wpctl inspect @DEFAULT_AUDIO_SINK@ 2>/dev/null | sed -n 's/^id \([0-9]\+\).*/\1/p'
+}
+
+id_of()   { printf '%s' "${SINKS[$1]%%$'\t'*}"; }
+name_of() { printf '%s' "${SINKS[$1]#*$'\t'}"; }
+
+index_of_current() {
+  local cur; cur=$(current)
+  local i
+  for i in "${!SINKS[@]}"; do
+    [[ "$(id_of "$i")" == "$cur" ]] && { printf '%s' "$i"; return; }
+  done
+  printf '%s' -1
+}
+
+pick() {
+  local i=$1
+  wpctl set-default "$(id_of "$i")" && echo "-> [$(id_of "$i")] $(name_of "$i")"
+}
+
+menu() {
+  local cur; cur=$(current)
+  echo "current default sink: ${cur:-unknown}"
+  local i
+  for i in "${!SINKS[@]}"; do
+    local mark=" "; [[ "$(id_of "$i")" == "$cur" ]] && mark="*"
+    printf " %s %d  [%s]  %s\n" "$mark" $((i + 1)) "$(id_of "$i")" "$(name_of "$i")"
+  done
+  echo
+  echo "usage: ab_sink.sh next | raw | <number>"
+}
+
+case "${1:-}" in
+  ""|-h|--help|status)
+    menu
+    ;;
+  next)
+    cur_idx=$(index_of_current)
+    pick $(( (cur_idx + 1) % ${#SINKS[@]} ))
+    ;;
+  raw)
+    for i in "${!SINKS[@]}"; do
+      [[ "$(name_of "$i")" != *Dolby* ]] && { pick "$i"; exit $?; }
+    done
+    echo "no non-Dolby sink found" >&2; exit 1
+    ;;
+  *[!0-9]*)
+    echo "unknown arg: $1" >&2; menu; exit 1
+    ;;
+  *)
+    n=$1
+    (( n >= 1 && n <= ${#SINKS[@]} )) || { echo "out of range (1-${#SINKS[@]})" >&2; exit 1; }
+    pick $(( n - 1 ))
+    ;;
+esac

--- a/tools/ab_sink.sh
+++ b/tools/ab_sink.sh
@@ -17,7 +17,9 @@ command -v wpctl  >/dev/null || { echo "wpctl not found (install wireplumber)" >
 command -v pw-dump >/dev/null || { echo "pw-dump not found" >&2; exit 1; }
 
 # Menu order: Dolby variants first (sorted), then everything else. One entry per
-# line as "<id>\t<label>".
+# line as "<id>\t<rank>\t<label>", where rank picks what `raw` means: 0 = this
+# machine's analog speaker, 1 = some other output (HDMI, Bluetooth, a null
+# sink), 9 = a Dolby variant, never raw.
 mapfile -t SINKS < <(
   pw-dump | python3 -c '
 import json, sys
@@ -26,8 +28,15 @@ sinks = [n for n in json.load(sys.stdin)
 def label(n):
     p = n["info"]["props"]
     return p.get("node.description") or p.get("node.name") or "?"
+def rank(n):
+    if "Dolby" in label(n):
+        return 9
+    name = (n["info"]["props"].get("node.name") or "").lower()
+    analog = name.startswith("alsa_output.") and not any(
+        d in name for d in ("hdmi", "iec958", "spdif", "bluez"))
+    return 0 if analog else 1
 for n in sorted(sinks, key=lambda n: (0 if "Dolby" in label(n) else 1, label(n))):
-    print(str(n["id"]) + "\t" + label(n))
+    print(str(n["id"]) + "\t" + str(rank(n)) + "\t" + label(n))
 '
 )
 (( ${#SINKS[@]} )) || { echo "no audio sinks found" >&2; exit 1; }
@@ -38,7 +47,8 @@ current() {
 }
 
 id_of()   { printf '%s' "${SINKS[$1]%%$'\t'*}"; }
-name_of() { printf '%s' "${SINKS[$1]#*$'\t'}"; }
+name_of() { printf '%s' "${SINKS[$1]##*$'\t'}"; }
+rank_of() { local r="${SINKS[$1]#*$'\t'}"; printf '%s' "${r%%$'\t'*}"; }
 
 index_of_current() {
   local cur; cur=$(current)
@@ -51,7 +61,9 @@ index_of_current() {
 
 pick() {
   local i=$1
-  wpctl set-default "$(id_of "$i")" && echo "-> [$(id_of "$i")] $(name_of "$i")"
+  wpctl set-default "$(id_of "$i")" || {
+    echo "wpctl could not make [$(id_of "$i")] the default sink" >&2; return 1; }
+  echo "-> [$(id_of "$i")] $(name_of "$i")"
 }
 
 menu() {
@@ -75,16 +87,22 @@ case "${1:-}" in
     pick $(( (cur_idx + 1) % ${#SINKS[@]} ))
     ;;
   raw)
+    # Best rank wins, so a Bluetooth headset or an HDMI sink can never stand in
+    # for the speaker you are trying to hear the voicings against.
+    best=-1
     for i in "${!SINKS[@]}"; do
-      [[ "$(name_of "$i")" != *Dolby* ]] && { pick "$i"; exit $?; }
+      r=$(rank_of "$i")
+      (( r == 9 )) && continue
+      if (( best < 0 )) || (( r < $(rank_of "$best") )); then best=$i; fi
     done
-    echo "no non-Dolby sink found" >&2; exit 1
+    (( best >= 0 )) || { echo "no non-Dolby sink found" >&2; exit 1; }
+    pick "$best"; exit $?
     ;;
   *[!0-9]*)
     echo "unknown arg: $1" >&2; menu; exit 1
     ;;
   *)
-    n=$1
+    n=$((10#$1))
     (( n >= 1 && n <= ${#SINKS[@]} )) || { echo "out of range (1-${#SINKS[@]})" >&2; exit 1; }
     pick $(( n - 1 ))
     ;;

--- a/tools/fetch_driver/README.md
+++ b/tools/fetch_driver/README.md
@@ -24,7 +24,8 @@ What it does:
    audio package whose descriptor advertises a HardwareID for this machine's
    codec (`VEN_10EC&DEV_xxxx`), breaking ties toward the Dolby DAX3 APO and
    then the highest version.
-3. Downloads the driver EXE into `./driver-cache/` and verifies its SHA-256
+3. Downloads the driver EXE into the repo's `driver-cache/` (gitignored;
+   `--driver-cache DIR` moves it) and verifies its SHA-256
    against the catalog descriptor.
 4. Runs `innoextract` to pull the `DEV_*_SUBSYS_*.xml` tuning files out, then
    prints that directory and the converter command to run next.

--- a/tools/fetch_driver/README.md
+++ b/tools/fetch_driver/README.md
@@ -28,7 +28,9 @@ What it does:
    `--driver-cache DIR` moves it) and verifies its SHA-256
    against the catalog descriptor.
 4. Runs `innoextract` to pull the `DEV_*_SUBSYS_*.xml` tuning files out, then
-   prints that directory and the converter command to run next.
+   prints that directory and the converter command to run next — a bare
+   `python3 dolby_to_easyeffects.py` where the autoprobe would find the
+   extraction on its own, `--windows DIR` where it wouldn't.
 
 Prerequisites: `innoextract` — the script names the package for your distro if
 it's missing. The converters' own dependencies (`lsp-plugins-lv2` etc.) are

--- a/tools/fetch_driver/README.md
+++ b/tools/fetch_driver/README.md
@@ -1,0 +1,40 @@
+# tools/fetch_driver — get the Dolby tuning XML without Windows
+
+The converters need the Dolby DAX3 tuning XML that ships inside the Windows
+audio driver. On a Lenovo laptop with no Windows partition,
+`get_lenovo_dax_xml.py` does the fetch-and-unpack step and prints the
+directory to hand to whichever converter you run.
+
+This is a staging area, not a permanent home: the fetch step is meant to move
+*inside* the converters (`dolby_to_easyeffects.py` growing a "no XML found,
+fetch it?" prompt), so it deliberately stops at the XML rather than driving a
+converter itself.
+
+## get_lenovo_dax_xml.py
+
+```bash
+python3 tools/fetch_driver/get_lenovo_dax_xml.py --dry-run   # resolve only, touch nothing
+python3 tools/fetch_driver/get_lenovo_dax_xml.py             # fetch + verify + unpack
+```
+
+What it does:
+
+1. Reads the Lenovo machine type and HDA codec IDs from sysfs / `/proc/asound`.
+2. Downloads the machine-type catalog from `download.lenovo.com` and picks the
+   audio package whose descriptor advertises a HardwareID for this machine's
+   codec (`VEN_10EC&DEV_xxxx`), breaking ties toward the Dolby DAX3 APO and
+   then the highest version.
+3. Downloads the driver EXE into `./driver-cache/` and verifies its SHA-256
+   against the catalog descriptor.
+4. Runs `innoextract` to pull the `DEV_*_SUBSYS_*.xml` tuning files out, then
+   prints that directory and the converter command to run next.
+
+Prerequisites: `innoextract` — the script names the package for your distro if
+it's missing. The converters' own dependencies (`lsp-plugins-lv2` etc.) are
+listed in the repo README; you only need them once you run a converter.
+
+Flags: `--windows-version {11,10,both}`, `--exe-url URL` (skip catalog
+resolution), `--machine-type MT`, `--driver-cache DIR`, `--keep-exe`,
+`--dry-run`.
+
+Other vendors aren't automated — see the repo README "Extracting the XML".

--- a/tools/fetch_driver/get_lenovo_dax_xml.py
+++ b/tools/fetch_driver/get_lenovo_dax_xml.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Zero-touch fetch of a Lenovo laptop's Dolby DAX3 tuning XML.
+
+The converters (dolby_to_easyeffects.py / dolby_to_pipewire.py) need the DAX3
+tuning XML that ships inside the Windows audio driver. On a Linux-only machine
+that means hand-downloading the OEM driver EXE and running innoextract. This
+script does that step and stops there: it reads the machine type and audio
+codec IDs from sysfs, resolves the matching audio-driver package from Lenovo's
+public update catalog, downloads and checksum-verifies the EXE, extracts the
+Dolby tuning XMLs into ./driver-cache/, and prints the directory to hand to
+whichever converter you want to run.
+
+Lenovo only, for now. Other vendors: see the README "Extracting the XML".
+
+  python3 tools/fetch_driver/get_lenovo_dax_xml.py            # fetch + unpack
+  python3 tools/fetch_driver/get_lenovo_dax_xml.py --dry-run  # show the plan, touch nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from lib import packages  # noqa: E402
+from lib.dax import discover  # noqa: E402
+from lib.hardware import codecs  # noqa: E402
+
+CATALOG_URL = "https://download.lenovo.com/catalog/{mt}_Win{win}.xml"
+UA = "Mozilla/5.0 (X11; Linux x86_64) get_lenovo_dax_xml/1"
+DOLBY_APO_HWID = "VEN_DOLBY&PID_DAX3"
+# Package-name prefixes that are dock / USB audio, not the internal codec.
+_NOT_INTERNAL = ("DOCK_", "AUDIO_U3AUD")
+
+# innoextract's package name per family (no row in lib/packages.py — it is not
+# a dependency of the converters, only of this helper). The install *verb* is
+# not ours to keep: `packages.install_verb` owns it, one table for every
+# caller.
+_INNOEXTRACT = {
+    packages.DEBIAN: "innoextract", packages.FEDORA: "innoextract",
+    packages.SUSE: "innoextract", packages.ARCH: "innoextract",
+    packages.ALPINE: "innoextract", packages.GENTOO: "app-arch/innoextract",
+}
+
+
+class Fail(RuntimeError):
+    """A user-facing failure; main() prints it and exits 1."""
+
+
+# --- machine identity -------------------------------------------------------
+
+def _dmi(field: str) -> str:
+    try:
+        return Path("/sys/class/dmi/id", field).read_text().strip()
+    except OSError:
+        return ""
+
+
+def machine_type() -> str:
+    """The 4-char Lenovo machine type (e.g. ``20XL``), or "" if not Lenovo."""
+    if "LENOVO" not in _dmi("sys_vendor").upper():
+        return ""
+    sku = _dmi("product_sku")
+    m = re.search(r"MT_([0-9A-Z]{4})", sku)
+    if m:
+        return m.group(1)
+    name = _dmi("product_name")[:4].upper()
+    return name if re.fullmatch(r"[0-9A-Z]{4}", name) else ""
+
+
+def codec_tokens() -> list[tuple[str, str, str, str]]:
+    """``(ven, dev, subsys, name)`` per HDA codec.
+
+    ``ven``/``dev`` are the 4-hex halves of the HDA vendor id (10EC0257 ->
+    10EC, 0257); together they form the ``VEN_10EC&DEV_0257`` HardwareID a
+    driver descriptor advertises, and ``dev``/``subsys`` the filename tokens.
+    """
+    out = []
+    for vendor_id, subsys_id, name in codecs.get_hda_codec_ids():
+        if subsys_id.upper().startswith("00"):  # HDMI/DP controllers
+            continue
+        out.append((vendor_id[:4].upper(), vendor_id[-4:].upper(),
+                    subsys_id.upper(), name))
+    return out
+
+
+# --- Lenovo catalog --------------------------------------------------------
+
+def _get(url: str) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.read()
+    except urllib.error.HTTPError as e:
+        raise Fail(f"{url} -> HTTP {e.code}")
+    except (urllib.error.URLError, TimeoutError) as e:
+        raise Fail(f"{url} -> {e}")
+
+
+def catalog_packages(mt: str, wins: list[str]) -> list[str]:
+    """Descriptor-XML URLs for every package in the machine-type catalog(s)."""
+    seen: dict[str, None] = {}
+    errors = []
+    for win in wins:
+        url = CATALOG_URL.format(mt=mt, win=win)
+        try:
+            root = ET.fromstring(_get(url))
+        except Fail as e:
+            errors.append(str(e))
+            continue
+        for pkg in root.findall("package"):
+            loc = pkg.findtext("location", "").strip()
+            cat = pkg.findtext("category", "").strip().lower()
+            if not loc:
+                continue
+            if cat == "audio":
+                seen.setdefault(loc, None)
+    if not seen and errors:
+        raise Fail("no catalog reachable for machine type "
+                   f"{mt}:\n  " + "\n  ".join(errors))
+    return list(seen)
+
+
+def _version_key(v: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in re.findall(r"\d+", v)[:4]) or (0,)
+
+
+class Descriptor:
+    def __init__(self, url: str, xml: bytes):
+        self.url = url
+        root = ET.fromstring(xml)
+        pkg = root if root.tag == "Package" else root.find(".//Package")
+        self.name = (pkg.get("name") if pkg is not None else "") or ""
+        self.version = (pkg.get("version") if pkg is not None else "") or ""
+        self.hwids = " ".join(e.text or "" for e in root.iter("HardwareID"))
+        self.exe_name = ""
+        self.sha256 = ""
+        for f in root.iter("File"):
+            nm = (f.findtext("Name") or "").strip()
+            if nm.lower().endswith(".exe"):
+                self.exe_name = nm
+                self.sha256 = (f.findtext("CRC") or "").strip().lower()
+                break
+
+    @property
+    def is_internal_audio(self) -> bool:
+        return not self.name.upper().startswith(_NOT_INTERNAL)
+
+    @property
+    def has_dolby_apo(self) -> bool:
+        return DOLBY_APO_HWID in self.hwids.upper()
+
+    def serves_codec(self, tokens: list[tuple[str, str, str, str]]) -> bool:
+        """True if a HardwareID names one of this machine's HDA codecs.
+
+        The descriptor lists the ``VEN_xxxx&DEV_xxxx`` it installs for, so a
+        match on the codec read from ``/proc/asound`` is a far stronger signal
+        than the package name or the Dolby-APO hwid — and it drops display
+        packages (the Dolby *Vision* Provisioning Kit) that carry neither.
+        """
+        hw = self.hwids.upper()
+        return any(f"VEN_{ven}&DEV_{dev}" in hw for ven, dev, _s, _n in tokens)
+
+    @property
+    def exe_url(self) -> str:
+        return self.url.rsplit("/", 1)[0] + "/" + self.exe_name
+
+
+def pick_descriptor(urls: list[str],
+                    tokens: list[tuple[str, str, str, str]]) -> Descriptor:
+    cands = []
+    for u in urls:
+        try:
+            d = Descriptor(u, _get(u))
+        except (ET.ParseError, Fail):
+            continue
+        if d.exe_name and d.is_internal_audio:
+            cands.append(d)
+    if not cands:
+        raise Fail("found audio packages in the catalog but none look like an "
+                   "internal-codec driver; pass --exe-url with the driver EXE")
+    # Primary key: the descriptor advertises this machine's codec. Only narrow
+    # to it when at least one does — a --machine-type override on another box,
+    # or a codec sysfs can't read, leaves every candidate in the running.
+    serving = [d for d in cands if d.serves_codec(tokens)]
+    pool = serving or cands
+    # Tiebreak between real audio drivers: the Dolby DAX3 APO, then version.
+    return max(pool, key=lambda d: (d.has_dolby_apo, _version_key(d.version)))
+
+
+# --- download + extract ---------------------------------------------------
+
+def download(url: str, dest: Path, expect_sha: str) -> Path:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    h = hashlib.sha256()
+    if dest.exists() and expect_sha:
+        h_existing = hashlib.sha256(dest.read_bytes()).hexdigest()
+        if h_existing == expect_sha:
+            print(f"  cached {dest.name} (sha256 ok)")
+            return dest
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    print(f"  downloading {url}")
+    tty = sys.stderr.isatty()
+    with urllib.request.urlopen(req, timeout=60) as r, open(dest, "wb") as fh:
+        total = int(r.headers.get("Content-Length", 0))
+        done = last_pct = 0
+        while chunk := r.read(1 << 16):
+            fh.write(chunk)
+            h.update(chunk)
+            done += len(chunk)
+            if total:
+                pct = done * 100 // total
+                if pct != last_pct and (tty or pct % 20 == 0):
+                    last_pct = pct
+                    end = "\r" if tty else "\n"
+                    print(f"  {done / 1e6:5.1f} / {total / 1e6:.1f} MB "
+                          f"({pct:3d}%)", end=end, file=sys.stderr)
+        if total and tty:
+            print(file=sys.stderr)
+    got = h.hexdigest()
+    if expect_sha and got != expect_sha:
+        dest.unlink(missing_ok=True)
+        raise Fail(f"checksum mismatch for {dest.name}\n"
+                   f"  expected {expect_sha}\n  got      {got}")
+    return dest
+
+
+def extract(exe: Path, cache: Path) -> Path:
+    """Unpack *exe* into ``cache/extract`` and return that directory."""
+    if not shutil.which("innoextract"):
+        fam = packages.family()
+        verb = packages.install_verb(fam)
+        hint = (f"{verb} {_INNOEXTRACT[fam]}"
+                if verb and fam in _INNOEXTRACT else
+                "install 'innoextract' from your distribution")
+        raise Fail(f"innoextract is required to unpack {exe.name}\n  {hint}")
+    out = cache / "extract"
+    if out.exists():
+        shutil.rmtree(out)
+    dolby_filter = "code$GetExtractPath$/Dolby/03_dax_ext"
+    base = ["innoextract", "-s", "-d", str(out)]
+    subprocess.run(base + ["-I", dolby_filter, str(exe)],
+                   check=False, capture_output=True)
+    if not list(out.rglob("*.xml")):  # filter missed this layout; take it all
+        shutil.rmtree(out, ignore_errors=True)
+        r = subprocess.run(base + [str(exe)], capture_output=True, text=True)
+        if r.returncode != 0:
+            raise Fail(f"innoextract failed:\n{r.stderr.strip()}")
+    return out
+
+
+def tuning_xml_dir(extract_root: Path) -> Path:
+    """The single directory of Dolby tuning XMLs under a fresh extraction.
+
+    Reuses ``lib/dax/discover`` so the "which files count" question is
+    answered once, in the same place the converters answer it — and scoped to
+    ``extract_root`` so a hand-run ``innoextract -d ./driver-cache`` elsewhere
+    in the cache can't add a second copy.
+    """
+    dirs = discover.walk_for_dolby_xml_dirs(extract_root)
+    if not dirs:
+        raise Fail(f"unpacked {extract_root} but found no Dolby DAX3 tuning "
+                   "XML in it. Look inside and pass a file to the converter "
+                   "directly.")
+    if len(dirs) > 1:
+        raise Fail("Dolby tuning XMLs landed in more than one directory:\n  "
+                   + "\n  ".join(str(d) for d in dirs)
+                   + "\npass one to the converter's --windows yourself.")
+    return dirs[0]
+
+
+# --- driver ---------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="get_lenovo_dax_xml.py",
+        description=__doc__.split("\n\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--windows-version", choices=("11", "10", "both"),
+                   default="both", help="which Lenovo Win catalog to read "
+                   "(default: both, Win11 first)")
+    p.add_argument("--exe-url", help="skip catalog resolution; download this "
+                   "driver EXE directly")
+    p.add_argument("--machine-type", help="override the detected 4-char "
+                   "Lenovo machine type")
+    p.add_argument("--driver-cache", type=Path, default=ROOT / "driver-cache",
+                   help="working directory for the EXE and extracted XMLs "
+                   "(default: ./driver-cache, gitignored)")
+    p.add_argument("--keep-exe", action="store_true",
+                   help="don't delete the driver EXE after extraction")
+    p.add_argument("--dry-run", action="store_true",
+                   help="resolve and print the plan; download/extract nothing")
+    return p
+
+
+def _print_next_steps(xml_dir: Path) -> None:
+    rel = xml_dir
+    try:
+        rel = xml_dir.relative_to(Path.cwd())
+    except ValueError:
+        pass
+    # innoextract's layout has a `$` in it (`code$GetExtractPath$`), so the
+    # path has to be quoted to survive a paste into a shell.
+    q = shlex.quote(str(rel))
+    print(f"\nDolby tuning XMLs are in:\n  {rel}\n")
+    print("build a preset from that directory with either converter:")
+    print(f"  python3 dolby_to_easyeffects.py --windows {q}")
+    print(f"  python3 dolby_to_pipewire.py --windows {q}")
+
+
+def run(args: argparse.Namespace) -> int:
+    cache = args.driver_cache
+    tokens = codec_tokens()
+    if tokens:
+        print("audio codec: " + ", ".join(
+            f"{name} (DEV_{dev} SUBSYS_{sub})" for _v, dev, sub, name in tokens))
+
+    if args.exe_url:
+        exe_url, sha, pkg_name = args.exe_url, "", "(from --exe-url)"
+    else:
+        mt = args.machine_type or machine_type()
+        if not mt:
+            raise Fail("this does not look like a Lenovo machine "
+                       "(/sys/class/dmi/id/sys_vendor). Only Lenovo is "
+                       "automated — see the README 'Extracting the XML' "
+                       "for a manual route.")
+        wins = {"11": ["11"], "10": ["10"], "both": ["11", "10"]}[
+            args.windows_version]
+        print(f"machine type: {mt}  (catalog: Win{', Win'.join(wins)})")
+        desc = pick_descriptor(catalog_packages(mt, wins), tokens)
+        exe_url, sha, pkg_name = desc.exe_url, desc.sha256, desc.name
+        print(f"driver package: {pkg_name} v{desc.version}"
+              + ("  [Dolby DAX3 APO]" if desc.has_dolby_apo else ""))
+
+    exe = cache / exe_url.rsplit("/", 1)[1]
+    print(f"driver EXE: {exe_url}")
+    if sha:
+        print(f"sha256: {sha}")
+
+    if args.dry_run:
+        print("\n-- dry run, nothing written --")
+        print("would extract Dolby tuning XMLs into:", cache / "extract")
+        return 0
+
+    download(exe_url, exe, sha)
+    xml_dir = tuning_xml_dir(extract(exe, cache))
+    if not args.keep_exe:
+        exe.unlink(missing_ok=True)
+
+    xmls = discover.xmls_directly_under(xml_dir)
+    print(f"\nextracted {len(xmls)} Dolby tuning XML(s):")
+    for p in xmls:
+        print("  ", p.name)
+    _print_next_steps(xml_dir)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    args = build_parser().parse_args(argv)
+    try:
+        return run(args)
+    except Fail as e:
+        print(f"\nerror: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/fetch_driver/get_lenovo_dax_xml.py
+++ b/tools/fetch_driver/get_lenovo_dax_xml.py
@@ -356,16 +356,39 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _autoprobe_finds(xml_dir: Path) -> bool:
+    """True if a converter run from here would land on ``xml_dir`` by itself.
+
+    Asked with the probe's own helpers rather than guessed from the path, so
+    a second extracted tree in the way is answered correctly: the autoprobe
+    narrows several candidates to the one matching this machine, and only a
+    single survivor means a bare run is unambiguous.
+    """
+    try:
+        found = discover.walk_for_dolby_xml_dirs(Path.cwd())
+    except OSError:
+        return False
+    if xml_dir not in found:
+        return False
+    return len(found) == 1 or discover.dirs_for_this_machine(found) == [xml_dir]
+
+
 def _print_next_steps(xml_dir: Path) -> None:
     rel = xml_dir
     try:
         rel = xml_dir.relative_to(Path.cwd())
     except ValueError:
         pass
+    print(f"\nDolby tuning XMLs are in:\n  {rel}\n")
+    if _autoprobe_finds(xml_dir):
+        print("build a preset with either converter — run from here, they find "
+              "that directory themselves:")
+        print("  python3 dolby_to_easyeffects.py")
+        print("  python3 dolby_to_pipewire.py")
+        return
     # innoextract's layout has a `$` in it (`code$GetExtractPath$`), so the
     # path has to be quoted to survive a paste into a shell.
     q = shlex.quote(str(rel))
-    print(f"\nDolby tuning XMLs are in:\n  {rel}\n")
     print("build a preset from that directory with either converter:")
     print(f"  python3 dolby_to_easyeffects.py --windows {q}")
     print(f"  python3 dolby_to_pipewire.py --windows {q}")

--- a/tools/fetch_driver/get_lenovo_dax_xml.py
+++ b/tools/fetch_driver/get_lenovo_dax_xml.py
@@ -407,10 +407,16 @@ def run(args: argparse.Namespace) -> int:
     if not args.keep_exe:
         exe.unlink(missing_ok=True)
 
+    # A per-SKU package holds hundreds of tunings (696 in the IdeaPad 5x one);
+    # naming them all buries the directory and the command that follow.
+    list_up_to = 12
     xmls = discover.xmls_directly_under(xml_dir)
     print(f"\nextracted {len(xmls)} Dolby tuning XML(s):")
-    for p in xmls:
-        print("  ", p.name)
+    if len(xmls) <= list_up_to:
+        for p in xmls:
+            print("  ", p.name)
+    else:
+        print("   (the converter picks yours out of them)")
     _print_next_steps(xml_dir)
     return 0
 

--- a/tools/fetch_driver/get_lenovo_dax_xml.py
+++ b/tools/fetch_driver/get_lenovo_dax_xml.py
@@ -278,7 +278,10 @@ def extract(exe: Path, cache: Path) -> Path:
     base = ["innoextract", "-s", "-d", str(out)]
     subprocess.run(base + ["-I", dolby_filter, str(exe)],
                    check=False, capture_output=True)
-    if not list(out.rglob("*.xml")):  # filter missed this layout; take it all
+    # Judged by the same filter that reads the result: a directory holding only
+    # `_settings`/`_dmic` companions has no tuning XML, and retrying unfiltered
+    # is exactly what that case needs.
+    if not discover.walk_for_dolby_xml_dirs(out):  # filter missed this layout
         shutil.rmtree(out, ignore_errors=True)
         r = subprocess.run(base + [str(exe)], capture_output=True, text=True)
         if r.returncode != 0:
@@ -299,6 +302,14 @@ def tuning_xml_dir(extract_root: Path) -> Path:
         raise Fail(f"unpacked {extract_root} but found no Dolby DAX3 tuning "
                    "XML in it. Look inside and pass a file to the converter "
                    "directly.")
+    if len(dirs) > 1:
+        # Some installers (Legion Y540-15IRH, say) fan out into a directory
+        # per SKU. Picking the first would be picking another laptop's tuning,
+        # so narrow to the one holding an XML for this machine.
+        narrowed = discover.dirs_for_this_machine(dirs)
+        if len(narrowed) == 1:
+            return narrowed[0]
+        dirs = narrowed or dirs
     if len(dirs) > 1:
         raise Fail("Dolby tuning XMLs landed in more than one directory:\n  "
                    + "\n  ".join(str(d) for d in dirs)

--- a/tools/fetch_driver/get_lenovo_dax_xml.py
+++ b/tools/fetch_driver/get_lenovo_dax_xml.py
@@ -76,8 +76,12 @@ def machine_type() -> str:
     m = re.search(r"MT_([0-9A-Z]{4})", sku)
     if m:
         return m.group(1)
-    name = _dmi("product_name")[:4].upper()
-    return name if re.fullmatch(r"[0-9A-Z]{4}", name) else ""
+    # `product_name` is either an MT-prefixed code (`20XLS23200`) or a
+    # marketing name. Slicing four characters off the latter yields `THIN` /
+    # `IDEA`, which look like machine types and 404 the catalog, so match the
+    # whole string instead.
+    m = re.fullmatch(r"([0-9A-Z]{4})[A-Z0-9]{3,}", _dmi("product_name").upper())
+    return m.group(1) if m else ""
 
 
 def codec_tokens() -> list[tuple[str, str, str, str]]:
@@ -89,7 +93,10 @@ def codec_tokens() -> list[tuple[str, str, str, str]]:
     """
     out = []
     for vendor_id, subsys_id, name in codecs.get_hda_codec_ids():
-        if subsys_id.upper().startswith("00"):  # HDMI/DP controllers
+        # Keyed on the codec name, the way `_card_pci_preference` does it: an
+        # SSID test catches the AMD spelling (`00AA0100`) but not Intel's
+        # (`80860101`), and a display codec has no Dolby tuning either way.
+        if "HDMI" in name.upper():
             continue
         out.append((vendor_id[:4].upper(), vendor_id[-4:].upper(),
                     subsys_id.upper(), name))

--- a/tools/fetch_driver/get_lenovo_dax_xml.py
+++ b/tools/fetch_driver/get_lenovo_dax_xml.py
@@ -7,8 +7,8 @@ that means hand-downloading the OEM driver EXE and running innoextract. This
 script does that step and stops there: it reads the machine type and audio
 codec IDs from sysfs, resolves the matching audio-driver package from Lenovo's
 public update catalog, downloads and checksum-verifies the EXE, extracts the
-Dolby tuning XMLs into ./driver-cache/, and prints the directory to hand to
-whichever converter you want to run.
+Dolby tuning XMLs into the repo's driver-cache/, and prints the directory to
+hand to whichever converter you want to run.
 
 Lenovo only, for now. Other vendors: see the README "Extracting the XML".
 
@@ -52,6 +52,7 @@ _INNOEXTRACT = {
     packages.DEBIAN: "innoextract", packages.FEDORA: "innoextract",
     packages.SUSE: "innoextract", packages.ARCH: "innoextract",
     packages.ALPINE: "innoextract", packages.GENTOO: "app-arch/innoextract",
+    packages.NIXOS: "innoextract",
 }
 
 
@@ -214,7 +215,8 @@ def pick_descriptor(urls: list[str],
                        "pass --exe-url with the driver EXE")
         detail = ("\n  " + "\n  ".join(skipped)) if skipped else ""
         raise Fail("found audio packages in the catalog but none look like an "
-                   f"internal-codec driver; pass --exe-url with the driver EXE{detail}")
+                   "internal-codec driver; pass --exe-url with the driver "
+                   f"EXE{detail}")
     # Primary key: the descriptor advertises this machine's codec. Only narrow
     # to it when at least one does — a --machine-type override on another box,
     # or a codec sysfs can't read, leaves every candidate in the running.
@@ -274,9 +276,15 @@ def extract(exe: Path, cache: Path) -> Path:
     if not shutil.which("innoextract"):
         fam = packages.family()
         verb = packages.install_verb(fam)
-        hint = (f"{verb} {_INNOEXTRACT[fam]}"
-                if verb and fam in _INNOEXTRACT else
-                "install 'innoextract' from your distribution")
+        pkg = _INNOEXTRACT.get(fam)
+        if fam == packages.NIXOS and pkg:
+            # innoextract is exec'd by this process, which is exactly what a
+            # nix-shell reaches — the NIX_SHELL_KEYS rationale in lib/packages.py.
+            hint = f"nix-shell -p {pkg}"
+        elif verb and pkg:
+            hint = f"{verb} {pkg}"
+        else:
+            hint = "install 'innoextract' from your distribution"
         raise Fail(f"innoextract is required to unpack {exe.name}\n  {hint}")
     out = cache / "extract"
     if out.exists():
@@ -340,7 +348,7 @@ def build_parser() -> argparse.ArgumentParser:
                    "Lenovo machine type")
     p.add_argument("--driver-cache", type=Path, default=ROOT / "driver-cache",
                    help="working directory for the EXE and extracted XMLs "
-                   "(default: ./driver-cache, gitignored)")
+                   "(default: driver-cache/ beside this repo, gitignored)")
     p.add_argument("--keep-exe", action="store_true",
                    help="don't delete the driver EXE after extraction")
     p.add_argument("--dry-run", action="store_true",

--- a/tools/fetch_driver/get_lenovo_dax_xml.py
+++ b/tools/fetch_driver/get_lenovo_dax_xml.py
@@ -26,6 +26,7 @@ import shutil
 import subprocess
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -150,7 +151,12 @@ class Descriptor:
             nm = (f.findtext("Name") or "").strip()
             if nm.lower().endswith(".exe"):
                 self.exe_name = nm
-                self.sha256 = (f.findtext("CRC") or "").strip().lower()
+                # `<CRC>` is a SHA-256 on every descriptor we've read, but the
+                # tag name doesn't promise one. Anything that isn't 64 hex is
+                # some other digest: skip verification rather than fail every
+                # run of this machine type on a mismatch we'd blame on the file.
+                crc = (f.findtext("CRC") or "").strip().lower()
+                self.sha256 = crc if re.fullmatch(r"[0-9a-f]{64}", crc) else ""
                 break
 
     @property
@@ -180,16 +186,28 @@ class Descriptor:
 def pick_descriptor(urls: list[str],
                     tokens: list[tuple[str, str, str, str]]) -> Descriptor:
     cands = []
+    # Why each rejected URL was rejected. Without this a run where every
+    # descriptor 403s reports "none look like an internal-codec driver" — a
+    # true statement about an empty list, and the wrong thing to go fix.
+    skipped = []
     for u in urls:
         try:
             d = Descriptor(u, _get(u))
-        except (ET.ParseError, Fail):
+        except Fail as e:
+            skipped.append(str(e))
+            continue
+        except ET.ParseError as e:
+            skipped.append(f"{u} -> not XML ({e})")
             continue
         if d.exe_name and d.is_internal_audio:
             cands.append(d)
     if not cands:
+        if not urls:
+            raise Fail("this machine type's catalog lists no audio package; "
+                       "pass --exe-url with the driver EXE")
+        detail = ("\n  " + "\n  ".join(skipped)) if skipped else ""
         raise Fail("found audio packages in the catalog but none look like an "
-                   "internal-codec driver; pass --exe-url with the driver EXE")
+                   f"internal-codec driver; pass --exe-url with the driver EXE{detail}")
     # Primary key: the descriptor advertises this machine's codec. Only narrow
     # to it when at least one does — a --machine-type override on another box,
     # or a codec sysfs can't read, leaves every candidate in the running.
@@ -212,22 +230,30 @@ def download(url: str, dest: Path, expect_sha: str) -> Path:
     req = urllib.request.Request(url, headers={"User-Agent": UA})
     print(f"  downloading {url}")
     tty = sys.stderr.isatty()
-    with urllib.request.urlopen(req, timeout=60) as r, open(dest, "wb") as fh:
-        total = int(r.headers.get("Content-Length", 0))
-        done = last_pct = 0
-        while chunk := r.read(1 << 16):
-            fh.write(chunk)
-            h.update(chunk)
-            done += len(chunk)
-            if total:
-                pct = done * 100 // total
-                if pct != last_pct and (tty or pct % 20 == 0):
-                    last_pct = pct
-                    end = "\r" if tty else "\n"
-                    print(f"  {done / 1e6:5.1f} / {total / 1e6:.1f} MB "
-                          f"({pct:3d}%)", end=end, file=sys.stderr)
-        if total and tty:
-            print(file=sys.stderr)
+    # Same conversion `_get` does: a 404 on a hand-passed --exe-url, or a
+    # connection dropped mid-download, is a user-facing failure, not a traceback.
+    try:
+        with urllib.request.urlopen(req, timeout=60) as r, open(dest, "wb") as fh:
+            total = int(r.headers.get("Content-Length", 0))
+            done = last_pct = 0
+            while chunk := r.read(1 << 16):
+                fh.write(chunk)
+                h.update(chunk)
+                done += len(chunk)
+                if total:
+                    pct = done * 100 // total
+                    if pct != last_pct and (tty or pct % 20 == 0):
+                        last_pct = pct
+                        end = "\r" if tty else "\n"
+                        print(f"  {done / 1e6:5.1f} / {total / 1e6:.1f} MB "
+                              f"({pct:3d}%)", end=end, file=sys.stderr)
+            if total and tty:
+                print(file=sys.stderr)
+    except urllib.error.HTTPError as e:
+        raise Fail(f"{url} -> HTTP {e.code}")
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        dest.unlink(missing_ok=True)
+        raise Fail(f"{url} -> {e}")
     got = h.hexdigest()
     if expect_sha and got != expect_sha:
         dest.unlink(missing_ok=True)
@@ -343,7 +369,12 @@ def run(args: argparse.Namespace) -> int:
         print(f"driver package: {pkg_name} v{desc.version}"
               + ("  [Dolby DAX3 APO]" if desc.has_dolby_apo else ""))
 
-    exe = cache / exe_url.rsplit("/", 1)[1]
+    # Not `rsplit("/")`: a --exe-url ending in "/" would name the cache dir
+    # itself, and a query string would end up in the filename.
+    exe_name = Path(urllib.parse.urlparse(exe_url).path).name
+    if not exe_name:
+        raise Fail(f"no filename in {exe_url}")
+    exe = cache / exe_name
     print(f"driver EXE: {exe_url}")
     if sha:
         print(f"sha256: {sha}")


### PR DESCRIPTION
On a Lenovo laptop with no Windows partition, getting the DAX3 tuning XML
today means hand-downloading the OEM driver EXE and running `innoextract`.
This adds `tools/fetch_driver/get_lenovo_dax_xml.py`, which does that step:
it reads the machine type and HDA codec IDs from sysfs, resolves the matching
audio-driver package from Lenovo's public update catalog, downloads and
SHA-256-verifies the EXE, extracts the `DEV_*_SUBSYS_*.xml` tuning files, and
(unless `--no-install`) hands off to `dolby_to_pipewire.py`.

`tools/fetch_driver/ab.sh` flips the default sink between the generated
voicings and the raw speaker (via `wpctl`) for an A/B listen.

Lenovo-only for the catalog resolution — `--exe-url` is the generic escape
hatch for a driver EXE you already have a URL for. Other vendors are pointed
at the existing README "Extracting the XML" section.

- Script is stdlib-only; imports `lib.packages` and `lib.hardware.codecs`.
- `innoextract` is wrapped, not reimplemented — missing-dependency errors name
  the distro package.
- Writes only to `./driver-cache/` (already gitignored, already the
  `innoextract` output dir used by `lib/dax/discover.py`).
- `tests/test_fetch_driver.py` — 10 fast, network-free tests (catalog
  filtering, descriptor pick / Dolby-APO preference / version tie-break,
  checksum abort, machine-type parsing, subsystem byte-order match).
- README + CHANGELOG + `tools/README.md` updated.

Built and exercised end-to-end on a ThinkPad T14 Gen 2 AMD (20XL) — that
device's tested-list entry is in a separate PR.

`--dry-run` on that machine:
```
audio codec: Realtek ALC257 (DEV_0257 SUBSYS_17AA5094)
machine type: 20XL  (catalog: Win11, Win10)
driver package: AUD_R1MAR v6.0.9366.1  [Dolby DAX3 APO]
driver EXE: https://download.lenovo.com/pccbbs/mobiles/r1mra06w.exe
sha256: e6bd6da964cf301a0c91ce42ef0436ce66435728377c22f12b85743a5e860ff0
-- dry run, nothing written --
would hand off: dolby_to_pipewire.py --windows '<dir of extracted DAX3 XMLs>' --variant all --target-sink ''
```